### PR TITLE
fix(TD-003) : solde des avoirs — deux vues divergentes réconciliées

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed — TD-003 : solde des avoirs (2026-08-10)
+- **Un avoir consommé à la main pouvait être réimputé automatiquement.** Le
+  solde d'un avoir se lisait de deux façons divergentes : le règlement manuel
+  agrégeait les allocations sans jamais décrémenter
+  `ParentCredit.amountRemaining`, sur lequel s'appuie le FIFO de US-FACT-02. Un
+  avoir réglé manuellement restait donc « plein » pour l'imputation automatique,
+  qui pouvait le consommer une seconde fois — le compte 4191 se retrouvant
+  débité de plus qu'il n'avait été crédité. Les deux chemins tiennent désormais
+  les deux vues à jour, et le règlement manuel écrit lui aussi son historique de
+  consommation.
+- **Supprimer un règlement par avoir restitue le crédit.** L'allocation est
+  décrémentée ou supprimée, la ligne d'historique retirée et le solde recrédité
+  (plafonné au montant initial, pour qu'une double suppression ne gonfle pas
+  l'avoir). Auparavant les écritures étaient bien annulées mais l'avoir restait
+  compté comme utilisé.
+- Diagnostic en lecture seule des données antérieures :
+  `prisma/migrations-manual/2026-08-10-diagnostic-solde-avoirs.sql`.
+
 ### Added — backlog MIKADO (2026-08-09)
 - **US-FACT-02 — déduction automatique des avoirs sur la facture suivante.**
   À l'émission d'une facture (DRAFT → SENT), les crédits disponibles du client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,14 @@ Chaque imputation ecrit aussi une `CreditApplication` (historique metier affiche
 sur la fiche de l'avoir) et une `CreditNoteAllocation` (miroir du chemin manuel
 `payments.create`, qui agrege ce modele pour interdire une double consommation).
 
+**Second invariant (TD-003)** : le solde d'un avoir a DEUX representations —
+`ParentCredit.amountRemaining` et la somme des `CreditNoteAllocation`. Les deux
+chemins d'imputation (automatique et manuel via `payments.create`) doivent
+mettre a jour les DEUX, et `payments.delete` doit les restituer via
+`restoreCreditOnPaymentDeletion()`. Si un chemin n'en met qu'une a jour, un
+avoir consomme peut etre reimpute par le FIFO et le compte 4191 se retrouve
+debite plus qu'il n'a ete credite.
+
 ### Plus de RLS PostgreSQL
 Le filtrage est applicatif via Prisma extensions. Le `soft-delete.extension.ts`
 filtre automatiquement les enregistrements supprimes. Le filtrage par tenant/parent
@@ -133,7 +141,7 @@ Pour chaque router :
 ## Documents
 
 - `docs/deploiement.md` — topologie Vercel/Neon, vars d'env, procedure de migration, incident 2025-11.
-- `docs/dette-technique.md` — registre de dette (TD-001 typage any des mappers OPEN ; TD-002 factures legacy 0 XPF DONE ; TD-003 solde d'avoir non restaure a la suppression d'un paiement OPEN ; TD-A2 couverture PDF facture DONE).
+- `docs/dette-technique.md` — registre de dette (TD-001 typage any des mappers OPEN ; TD-002 factures legacy 0 XPF DONE ; TD-003 divergence des deux vues du solde d'un avoir DONE ; TD-A2 couverture PDF facture DONE).
 - `docs/stories/BACKLOG.md` — backlog produit + **backlog MIKADO livre le 2026-08-09** (7 US, arbitrages US-FACT-02 tranches).
 - `docs/test-evidence/recette-v2.0.1/` — recette visuelle Playwright (19/19 PASS, `pnpm recette`) + rapport de preuve.
 - `CHANGELOG.md` — journal des livraisons (v2.0.0 premiere prod de la refonte + v2.0.1 correctifs campagne smoke, 2026-07-06).

--- a/docs/dette-technique.md
+++ b/docs/dette-technique.md
@@ -31,26 +31,50 @@ garde-fou ; 15 inscriptions CONFIRMED/UNPAID préservées et refacturables.
 **Reste (action ALVM)** : refacturer au bon tarif les inscriptions concernées
 via l'app (les montants se préremplissent depuis les tarifs des camps).
 
-## TD-003 — Suppression d'un paiement par avoir : allocation non reprise — P3 — OPEN
+## TD-003 — Solde d'un avoir : deux vues divergentes — P2 — DONE (2026-08-10)
 
-**Constat (2026-08-09, US-FACT-02)** : `payments.delete` supprime le paiement,
-annule ses écritures et recalcule `paid_amount`, mais ne supprime ni la
-`CreditNoteAllocation` ni la `CreditApplication` associées, et ne recrédite pas
-`ParentCredit.amountRemaining`. Un avoir consommé puis « dé-consommé » par
-suppression du paiement reste donc compté comme utilisé.
+**Constat initial (2026-08-09, US-FACT-02)** : `payments.delete` supprime le
+paiement, annule ses écritures et recalcule `paid_amount`, mais ne reprenait ni
+la `CreditNoteAllocation`, ni la `CreditApplication`, ni
+`ParentCredit.amountRemaining`. Un avoir « dé-consommé » restait compté comme
+utilisé.
 
-**Antériorité** : le défaut existe depuis le chemin manuel de règlement par
-avoir (`payments.create`) — il n'est pas introduit par l'imputation automatique,
-qui écrit exactement les mêmes enregistrements. US-FACT-02 le rend simplement
-plus fréquent, puisque les imputations deviennent automatiques.
+**Défaut plus large trouvé au traitement (P2, pas P3)** : le solde d'un avoir se
+lisait de **deux façons divergentes**.
 
-**Impact** : solde d'avoir sous-évalué après une suppression de paiement. Aucun
-impact comptable (les écritures BQ, elles, sont bien annulées).
+| Vue | Alimentée par | Lue par |
+|-----|---------------|---------|
+| `ABS(total_amount) - SUM(credit_note_allocations)` | chemin manuel `payments.create` | contrôle de solde du chemin manuel |
+| `ParentCredit.amountRemaining` | imputation automatique uniquement | FIFO de `applyAvailableCreditsToInvoice` |
 
-**Résolution cible** : dans `payments.delete`, si `creditNoteId` est renseigné,
-supprimer l'allocation et l'application correspondantes et ré-incrémenter
-`amountRemaining`, le tout dans la transaction existante. Prévoir un test
-« imputer → supprimer le paiement → solde restauré ».
+Le chemin manuel ne décrémentait **jamais** `amountRemaining`. Un avoir consommé
+à la main restait donc « plein » aux yeux du FIFO, qui pouvait le réimputer sur
+une facture suivante. Scénario : avoir de 5 000 appliqué manuellement sur la
+facture A, puis facture B validée → 5 000 réimputés. Le compte **4191 se
+retrouve débité de 10 000 pour 5 000 crédités** — déséquilibre de fond au FEC.
+
+Ce second volet n'était pas visible avant US-FACT-02 : tant que personne ne
+lisait `amountRemaining`, sa dérive était sans conséquence.
+
+**✅ Résolu (2026-08-10)** :
+- `payments.create` décrémente `amountRemaining` (plancher à 0) et écrit une
+  `CreditApplication`, pour que l'historique soit uniforme quel que soit le
+  chemin. Le garde-fou du chemin manuel reste le solde calculé sur les
+  allocations : comportement inchangé, aucun risque de régression.
+- `restoreCreditOnPaymentDeletion()` (`credit-application.service.ts`), appelé
+  par `payments.delete` avant la suppression : décrémente ou supprime
+  l'allocation, retire la ligne d'historique, recrédite `amountRemaining`
+  plafonné au montant initial (une double suppression ne peut pas gonfler
+  l'avoir).
+- Tests : 8 cas de service (dont le cycle imputation → suppression →
+  redisponibilité) et 7 cas de router. Vérifiés en échec sans le correctif.
+
+**Reste à faire côté données** : les avoirs consommés à la main **avant** ce
+correctif peuvent porter un `amount_remaining` surévalué. Diagnostic en lecture
+seule fourni : `prisma/migrations-manual/2026-08-10-diagnostic-solde-avoirs.sql`
+(la requête de réalignement est commentée dans le même fichier, à n'exécuter
+qu'après lecture des écarts). Volume attendu proche de zéro — les paiements
+réels sont quasi inexistants en prod à ce jour (cf. TD-002).
 
 ## TD-A2 — Couverture de test du PDF facture — P3 — DONE (2026-08-09)
 

--- a/prisma/migrations-manual/2026-08-10-diagnostic-solde-avoirs.sql
+++ b/prisma/migrations-manual/2026-08-10-diagnostic-solde-avoirs.sql
@@ -1,0 +1,91 @@
+-- ============================================================================
+-- Diagnostic 2026-08-10 (TD-003) — divergence entre les deux vues du solde
+-- d'un avoir. LECTURE SEULE : ce script ne modifie RIEN.
+--
+-- Contexte
+-- --------
+-- Le solde restant d'un avoir se lisait de deux façons qui pouvaient diverger :
+--   (A) chemin manuel (payments.create) : |invoices.total_amount| moins la
+--       somme des credit_note_allocations — il ne décrémentait PAS
+--       parent_credits.amount_remaining ;
+--   (B) chemin automatique (US-FACT-02) : parent_credits.amount_remaining.
+--
+-- Conséquence avant correctif : un avoir consommé à la main restait « plein »
+-- pour l'imputation automatique, qui pouvait le réimputer sur une autre
+-- facture. Le compte 4191 se retrouvait alors débité de plus qu'il n'avait été
+-- crédité.
+--
+-- Le code tient désormais les deux vues à jour dans les deux sens (imputation
+-- ET suppression de règlement). Reste à vérifier qu'aucune donnée ANTÉRIEURE
+-- au correctif ne porte déjà un écart.
+--
+-- Usage : exécuter sur un clone du dump de prod, puis sur la prod (lecture
+-- seule, sans risque). Si la requête ne renvoie AUCUNE ligne, il n'y a rien à
+-- reprendre. Sinon, voir la note de correction en fin de fichier.
+-- ============================================================================
+
+SELECT
+    cn.invoice_number                          AS avoir,
+    pc.id                                      AS parent_credit_id,
+    pc.amount_original                         AS montant_initial,
+    pc.amount_remaining                        AS solde_vue_automatique,
+    ABS(cn.total_amount) - COALESCE(alloc.total_alloue, 0)
+                                               AS solde_vue_allocations,
+    COALESCE(alloc.total_alloue, 0)            AS total_alloue,
+    COALESCE(app.total_historise, 0)           AS total_historise,
+    pc.amount_remaining
+      - (ABS(cn.total_amount) - COALESCE(alloc.total_alloue, 0))
+                                               AS ecart
+FROM parent_credits pc
+JOIN invoices cn
+  ON cn.id = pc.credit_note_id
+LEFT JOIN (
+    SELECT credit_note_id, SUM(amount) AS total_alloue
+    FROM credit_note_allocations
+    GROUP BY credit_note_id
+) alloc
+  ON alloc.credit_note_id = pc.credit_note_id
+LEFT JOIN (
+    SELECT parent_credit_id, SUM(amount_used) AS total_historise
+    FROM credit_applications
+    GROUP BY parent_credit_id
+) app
+  ON app.parent_credit_id = pc.id
+-- On ne remonte que les avoirs réellement incohérents.
+WHERE pc.amount_remaining
+      <> ABS(cn.total_amount) - COALESCE(alloc.total_alloue, 0)
+ORDER BY ABS(
+    pc.amount_remaining
+      - (ABS(cn.total_amount) - COALESCE(alloc.total_alloue, 0))
+) DESC;
+
+-- ============================================================================
+-- Si des lignes remontent
+-- ============================================================================
+-- La vue « allocations » fait foi : elle est alimentée depuis l'origine par le
+-- chemin manuel, alors que amount_remaining n'était mis à jour par personne
+-- avant US-FACT-02. La correction consiste donc à réaligner amount_remaining
+-- sur le solde calculé — MAIS elle ne doit être appliquée qu'après lecture des
+-- lignes ci-dessus et validation métier (un écart peut aussi signaler un avoir
+-- saisi à la main hors application).
+--
+-- Requête de correction, à n'exécuter QUE dans ce cas, sur clone d'abord :
+--
+--   UPDATE parent_credits pc
+--   SET amount_remaining = GREATEST(0, LEAST(
+--         pc.amount_original,
+--         ABS(cn.total_amount) - COALESCE((
+--           SELECT SUM(a.amount) FROM credit_note_allocations a
+--           WHERE a.credit_note_id = pc.credit_note_id
+--         ), 0)
+--       ))
+--   FROM invoices cn
+--   WHERE cn.id = pc.credit_note_id
+--     AND pc.amount_remaining <> ABS(cn.total_amount) - COALESCE((
+--           SELECT SUM(a.amount) FROM credit_note_allocations a
+--           WHERE a.credit_note_id = pc.credit_note_id
+--         ), 0);
+--
+-- Aucune écriture comptable n'est concernée : le compte 4191 est alimenté par
+-- les écritures BQ, que ce réalignement ne touche pas.
+-- ============================================================================

--- a/server/routers/payments.ts
+++ b/server/routers/payments.ts
@@ -8,6 +8,7 @@ import {
 } from '@/server/trpc/init';
 import type { Prisma } from '@prisma/client';
 import { createPaymentEntries, cancelAccountingEntries } from '@/server/services/accounting.service';
+import { restoreCreditOnPaymentDeletion } from '@/server/services/credit-application.service';
 import { toNum } from '@/server/helpers/decimal';
 import { generateDocumentNumber } from '@/server/helpers/invoice-number';
 
@@ -310,6 +311,42 @@ export const paymentsRouter = router({
             },
           });
 
+          // Le solde d'un avoir se lisait jusqu'ici de DEUX façons divergentes :
+          // ce chemin manuel agrégeait les `CreditNoteAllocation`, tandis que
+          // l'imputation automatique (US-FACT-02) s'appuie sur
+          // `ParentCredit.amountRemaining` — que ce chemin ne décrémentait pas.
+          // Un avoir consommé à la main restait donc « plein » pour le FIFO, qui
+          // pouvait le réimputer sur une autre facture : le compte 4191 se
+          // retrouvait débité de plus qu'il n'avait été crédité.
+          // Les deux vues sont désormais tenues à jour par les deux chemins.
+          const parentCredit = await tx.parentCredit.findFirst({
+            where: { creditNoteId: input.creditNoteId },
+          });
+
+          if (parentCredit) {
+            const remaining = toNum(parentCredit.amountRemaining);
+
+            await tx.parentCredit.update({
+              where: { id: parentCredit.id },
+              // Plancher à 0 plutôt qu'une erreur : le garde-fou du chemin
+              // manuel reste le solde calculé sur les allocations (ci-dessus,
+              // comportement inchangé). Ce plancher évite qu'un écart hérité
+              // ne bloque une saisie légitime.
+              data: { amountRemaining: Math.max(0, remaining - input.amount) },
+            });
+
+            // Historique uniforme quel que soit le chemin d'imputation.
+            await tx.creditApplication.create({
+              data: {
+                parentCreditId: parentCredit.id,
+                invoiceId: input.invoiceId,
+                amountUsed: input.amount,
+                appliedBy: userId,
+                notes: input.notes || `Imputation manuelle sur la facture ${invoice.invoiceNumber}`,
+              },
+            });
+          }
+
           creditNoteIsFutureCredit = creditNote.isFutureCredit ?? false;
         }
 
@@ -382,6 +419,18 @@ export const paymentsRouter = router({
 
         // Cancel associated accounting entries
         await cancelAccountingEntries(tx, { paymentId: input.id }, ctx.user.id);
+
+        // TD-003 — restituer le crédit avant de supprimer le paiement.
+        // Supprimer un règlement par avoir annulait bien les écritures, mais
+        // laissait l'avoir compté comme consommé : ni l'allocation, ni
+        // l'application, ni le solde n'étaient repris.
+        if (payment.creditNoteId) {
+          await restoreCreditOnPaymentDeletion(tx, {
+            creditNoteId: payment.creditNoteId,
+            invoiceId: payment.invoiceId,
+            amount: toNum(payment.amount),
+          });
+        }
 
         // Delete payment
         await tx.payment.delete({ where: { id: input.id } });

--- a/server/services/credit-application.service.ts
+++ b/server/services/credit-application.service.ts
@@ -48,6 +48,77 @@ import { createPaymentEntries } from '@/server/services/accounting.service';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TxClient = any;
 
+export interface RestoreCreditParams {
+  /** Avoir dont provenait le règlement supprimé. */
+  creditNoteId: string;
+  /** Facture sur laquelle il avait été imputé. */
+  invoiceId: string;
+  /** Montant du règlement supprimé. */
+  amount: number;
+}
+
+/**
+ * Restitue un crédit après suppression d'un règlement par avoir (TD-003).
+ *
+ * Symétrique exact de l'imputation : l'allocation est decrementee ou supprimee,
+ * la ligne d'historique correspondante est retiree, et `amountRemaining` est
+ * recredite — plafonne au montant initial pour qu'une double suppression ne
+ * puisse pas gonfler l'avoir au-dela de sa valeur.
+ *
+ * A appeler DANS la transaction de suppression, AVANT de supprimer le paiement
+ * (les identifiants sont lus depuis celui-ci).
+ */
+export async function restoreCreditOnPaymentDeletion(
+  tx: TxClient,
+  params: RestoreCreditParams
+): Promise<void> {
+  const { creditNoteId, invoiceId, amount } = params;
+
+  if (amount <= 0) return;
+
+  // 1. Allocation — vue « solde » du chemin manuel.
+  const allocation = await tx.creditNoteAllocation.findFirst({
+    where: { creditNoteId, appliedToInvoiceId: invoiceId },
+  });
+
+  if (allocation) {
+    const allocated = toNum(allocation.amount);
+
+    if (allocated > amount) {
+      // Plusieurs reglements sur la meme facture : on ne retire que la part
+      // du reglement supprime.
+      await tx.creditNoteAllocation.update({
+        where: { id: allocation.id },
+        data: { amount: allocated - amount },
+      });
+    } else {
+      await tx.creditNoteAllocation.delete({ where: { id: allocation.id } });
+    }
+  }
+
+  // 2. Credit parent — vue « solde » du chemin automatique.
+  const parentCredit = await tx.parentCredit.findFirst({ where: { creditNoteId } });
+  if (!parentCredit) return;
+
+  const original = toNum(parentCredit.amountOriginal);
+  const remaining = toNum(parentCredit.amountRemaining);
+
+  await tx.parentCredit.update({
+    where: { id: parentCredit.id },
+    data: { amountRemaining: Math.min(original, remaining + amount) },
+  });
+
+  // 3. Historique — retirer la ligne correspondant au reglement supprime.
+  const application = await tx.creditApplication.findFirst({
+    where: { parentCreditId: parentCredit.id, invoiceId, amountUsed: amount },
+    orderBy: { appliedAt: 'desc' },
+  });
+
+  if (application) {
+    await tx.creditApplication.delete({ where: { id: application.id } });
+  }
+}
+
 export interface ApplyCreditsParams {
   invoiceId: string;
   invoiceNumber: string;

--- a/test/unit/credit-restore.spec.ts
+++ b/test/unit/credit-restore.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * TD-003 — restitution d'un crédit à la suppression d'un règlement par avoir.
+ *
+ * Avant correctif, `payments.delete` annulait bien les écritures comptables mais
+ * laissait l'avoir compté comme consommé : ni la `CreditNoteAllocation`, ni la
+ * `CreditApplication`, ni `ParentCredit.amountRemaining` n'étaient repris.
+ *
+ * Ce fichier couvre aussi l'invariant qui rendait le défaut dangereux : les deux
+ * vues du solde d'un avoir (allocations agrégées côté chemin manuel,
+ * `amountRemaining` côté imputation automatique) doivent être tenues à jour par
+ * LES DEUX chemins. Sinon un avoir consommé à la main reste « plein » pour le
+ * FIFO, qui le réimpute — et le compte 4191 est débité plus qu'il n'a été crédité.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMockPrisma, type MockPrisma } from '../helpers/mock-prisma';
+import {
+  restoreCreditOnPaymentDeletion,
+  applyAvailableCreditsToInvoice,
+} from '@/server/services/credit-application.service';
+
+const INVOICE_ID = 'a0000000-0000-1000-a000-000000000001';
+const PARENT_ID = 'b0000000-0000-1000-a000-000000000001';
+const USER_ID = 'c0000000-0000-1000-a000-000000000001';
+const CREDIT_NOTE_ID = 'e0000000-0000-1000-a000-000000000001';
+
+let tx: MockPrisma;
+
+beforeEach(() => {
+  tx = createMockPrisma();
+});
+
+function arrangeAllocation(amount: number) {
+  tx.creditNoteAllocation.findFirst.mockResolvedValue({
+    id: 'alloc1',
+    creditNoteId: CREDIT_NOTE_ID,
+    appliedToInvoiceId: INVOICE_ID,
+    amount,
+  });
+}
+
+function arrangeParentCredit(original: number, remaining: number) {
+  tx.parentCredit.findFirst.mockResolvedValue({
+    id: 'cr1',
+    creditNoteId: CREDIT_NOTE_ID,
+    parentId: PARENT_ID,
+    amountOriginal: original,
+    amountRemaining: remaining,
+  });
+}
+
+const params = { creditNoteId: CREDIT_NOTE_ID, invoiceId: INVOICE_ID, amount: 2000 };
+
+describe('restoreCreditOnPaymentDeletion — solde du crédit (TD-003)', () => {
+  it('recrédite le solde du montant du règlement supprimé', async () => {
+    arrangeAllocation(2000);
+    arrangeParentCredit(5000, 3000);
+
+    await restoreCreditOnPaymentDeletion(tx, params);
+
+    expect(tx.parentCredit.update).toHaveBeenCalledWith({
+      where: { id: 'cr1' },
+      data: { amountRemaining: 5000 },
+    });
+  });
+
+  it('ne gonfle jamais le crédit au-delà de son montant initial', async () => {
+    // Solde déjà à son maximum : une suppression rejouée ne doit rien créer.
+    arrangeAllocation(2000);
+    arrangeParentCredit(5000, 5000);
+
+    await restoreCreditOnPaymentDeletion(tx, params);
+
+    expect(tx.parentCredit.update).toHaveBeenCalledWith({
+      where: { id: 'cr1' },
+      data: { amountRemaining: 5000 },
+    });
+  });
+
+  it("supprime l'allocation quand elle correspond exactement au règlement", async () => {
+    arrangeAllocation(2000);
+    arrangeParentCredit(5000, 3000);
+
+    await restoreCreditOnPaymentDeletion(tx, params);
+
+    expect(tx.creditNoteAllocation.delete).toHaveBeenCalledWith({ where: { id: 'alloc1' } });
+    expect(tx.creditNoteAllocation.update).not.toHaveBeenCalled();
+  });
+
+  it("décrémente l'allocation quand elle couvre plusieurs règlements", async () => {
+    arrangeAllocation(5000);
+    arrangeParentCredit(5000, 0);
+
+    await restoreCreditOnPaymentDeletion(tx, params);
+
+    expect(tx.creditNoteAllocation.update).toHaveBeenCalledWith({
+      where: { id: 'alloc1' },
+      data: { amount: 3000 },
+    });
+    expect(tx.creditNoteAllocation.delete).not.toHaveBeenCalled();
+  });
+
+  it("retire la ligne d'historique correspondante", async () => {
+    arrangeAllocation(2000);
+    arrangeParentCredit(5000, 3000);
+    tx.creditApplication.findFirst.mockResolvedValue({ id: 'app1' });
+
+    await restoreCreditOnPaymentDeletion(tx, params);
+
+    expect(tx.creditApplication.findFirst).toHaveBeenCalledWith({
+      where: { parentCreditId: 'cr1', invoiceId: INVOICE_ID, amountUsed: 2000 },
+      orderBy: { appliedAt: 'desc' },
+    });
+    expect(tx.creditApplication.delete).toHaveBeenCalledWith({ where: { id: 'app1' } });
+  });
+
+  it('reste sans effet pour un avoir sans crédit futur', async () => {
+    // IMMEDIATE_REFUND : allocation possible, mais aucun ParentCredit.
+    arrangeAllocation(2000);
+    tx.parentCredit.findFirst.mockResolvedValue(null);
+
+    await restoreCreditOnPaymentDeletion(tx, params);
+
+    expect(tx.parentCredit.update).not.toHaveBeenCalled();
+    expect(tx.creditApplication.delete).not.toHaveBeenCalled();
+  });
+
+  it('ne fait rien sur un montant nul', async () => {
+    await restoreCreditOnPaymentDeletion(tx, { ...params, amount: 0 });
+
+    expect(tx.creditNoteAllocation.findFirst).not.toHaveBeenCalled();
+    expect(tx.parentCredit.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('cycle imputation → suppression → réimputation', () => {
+  it('rend le crédit à nouveau disponible pour le FIFO', async () => {
+    // 1. Imputation automatique de 2 000 sur une facture de 10 000.
+    tx.paymentMethod.findFirst.mockResolvedValue({
+      id: 'pm1',
+      code: 'CREDIT_NOTE',
+      accountingCode: '411000',
+    });
+    tx.payment.create.mockResolvedValue({ id: 'pay1' });
+    tx.parentCredit.findMany.mockResolvedValue([
+      {
+        id: 'cr1',
+        creditNoteId: CREDIT_NOTE_ID,
+        parentId: PARENT_ID,
+        amountOriginal: 2000,
+        amountRemaining: 2000,
+        expiresAt: null,
+        creditNote: {
+          id: CREDIT_NOTE_ID,
+          invoiceNumber: 'AVO-1',
+          status: 'SENT',
+          isFutureCredit: true,
+        },
+      },
+    ]);
+
+    const applied = await applyAvailableCreditsToInvoice(tx, {
+      invoiceId: INVOICE_ID,
+      invoiceNumber: 'FAC-1',
+      parentId: PARENT_ID,
+      totalAmount: 10000,
+      paidAmount: 0,
+      userId: USER_ID,
+      now: new Date('2026-08-10T00:00:00Z'),
+    });
+
+    expect(applied.totalApplied).toBe(2000);
+    expect(tx.parentCredit.update).toHaveBeenCalledWith({
+      where: { id: 'cr1' },
+      data: { amountRemaining: 0 },
+    });
+
+    // 2. Suppression du règlement : le solde doit revenir à 2 000.
+    tx.parentCredit.update.mockClear();
+    arrangeAllocation(2000);
+    arrangeParentCredit(2000, 0);
+
+    await restoreCreditOnPaymentDeletion(tx, params);
+
+    expect(tx.parentCredit.update).toHaveBeenCalledWith({
+      where: { id: 'cr1' },
+      data: { amountRemaining: 2000 },
+    });
+  });
+});

--- a/test/unit/payments.spec.ts
+++ b/test/unit/payments.spec.ts
@@ -575,6 +575,99 @@ describe('payments router', () => {
       );
     });
 
+    // -----------------------------------------------------------------------
+    // TD-003 — le chemin manuel doit tenir à jour LES DEUX vues du solde
+    // -----------------------------------------------------------------------
+    describe('TD-003 — cohérence du solde de l\'avoir', () => {
+      /** Règlement manuel de 15 000 par un avoir de 20 000 ouvrant un crédit. */
+      function arrangeManualCreditPayment() {
+        staff.mockPrisma.invoice.findFirst
+          .mockResolvedValueOnce(fakeInvoice)
+          .mockResolvedValueOnce({
+            id: CREDIT_NOTE_ID,
+            invoiceType: 'CREDIT_NOTE',
+            totalAmount: -20000,
+            status: 'SENT',
+            parentId: PARENT_USER.id,
+            deletedAt: null,
+            isFutureCredit: true,
+          });
+        staff.mockPrisma.paymentMethod.findUnique.mockResolvedValue({
+          name: 'Avoir',
+          code: 'CREDIT_NOTE',
+          accountingCode: '411000',
+        });
+        staff.mockPrisma.creditNoteAllocation.aggregate.mockResolvedValue({ _sum: { amount: 0 } });
+        staff.mockPrisma.creditNoteAllocation.create.mockResolvedValue({});
+        staff.mockPrisma.payment.create.mockResolvedValue({
+          ...fakeCreatedPayment,
+          paymentMethod: { name: 'Avoir', code: 'CREDIT_NOTE' },
+        });
+        staff.mockPrisma.invoice.update.mockResolvedValue({});
+        staff.mockPrisma.$queryRawUnsafe.mockResolvedValue([{ entry_num: 'BQ202506150001' }]);
+        staff.mockPrisma.accountingEntry.create.mockResolvedValue({});
+      }
+
+      const manualPaymentInput = {
+        invoiceId: INVOICE_ID,
+        amount: 15000,
+        paymentDate: '2025-06-15',
+        paymentMethodId: CREDIT_NOTE_METHOD_ID,
+        creditNoteId: CREDIT_NOTE_ID,
+      };
+
+      it('décrémente amountRemaining pour que le FIFO ne réimpute pas l\'avoir', async () => {
+        // Sans cette décrémentation, l'imputation automatique voyait l'avoir
+        // encore « plein » et le réimputait sur une autre facture : le compte
+        // 4191 était débité de plus qu'il n'avait été crédité.
+        arrangeManualCreditPayment();
+        staff.mockPrisma.parentCredit.findFirst.mockResolvedValue({
+          id: 'cr1',
+          creditNoteId: CREDIT_NOTE_ID,
+          amountOriginal: 20000,
+          amountRemaining: 20000,
+        });
+
+        await staff.caller.payments.create(manualPaymentInput);
+
+        expect(staff.mockPrisma.parentCredit.update).toHaveBeenCalledWith({
+          where: { id: 'cr1' },
+          data: { amountRemaining: 5000 },
+        });
+      });
+
+      it("écrit l'historique de consommation, comme le chemin automatique", async () => {
+        arrangeManualCreditPayment();
+        staff.mockPrisma.parentCredit.findFirst.mockResolvedValue({
+          id: 'cr1',
+          creditNoteId: CREDIT_NOTE_ID,
+          amountOriginal: 20000,
+          amountRemaining: 20000,
+        });
+
+        await staff.caller.payments.create(manualPaymentInput);
+
+        expect(staff.mockPrisma.creditApplication.create).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            parentCreditId: 'cr1',
+            invoiceId: INVOICE_ID,
+            amountUsed: 15000,
+            appliedBy: STAFF_USER.id,
+          }),
+        });
+      });
+
+      it('reste sans effet pour un avoir sans crédit futur', async () => {
+        arrangeManualCreditPayment();
+        staff.mockPrisma.parentCredit.findFirst.mockResolvedValue(null);
+
+        await staff.caller.payments.create(manualPaymentInput);
+
+        expect(staff.mockPrisma.parentCredit.update).not.toHaveBeenCalled();
+        expect(staff.mockPrisma.creditApplication.create).not.toHaveBeenCalled();
+      });
+    });
+
     it('should skip accounting entries for immediate credit note payment', async () => {
       staff.mockPrisma.invoice.findFirst
         .mockResolvedValueOnce(fakeInvoice)
@@ -788,6 +881,81 @@ describe('payments router', () => {
       mockPrisma.invoice.findUniqueOrThrow.mockResolvedValue(fakeInvoiceForDelete);
       mockPrisma.invoice.update.mockResolvedValue({});
     }
+
+    // -----------------------------------------------------------------------
+    // TD-003 — restitution du crédit à la suppression d'un règlement par avoir
+    // -----------------------------------------------------------------------
+    describe('TD-003 — restitution du crédit', () => {
+      const creditPaymentForDelete = {
+        ...fakePaymentForDelete,
+        amount: 2000,
+        creditNoteId: CREDIT_NOTE_ID,
+      };
+
+      function setupCreditDeleteMocks(mockPrisma: TestCaller['mockPrisma']) {
+        setupDeleteMocks(mockPrisma);
+        mockPrisma.payment.findUnique.mockResolvedValue(creditPaymentForDelete);
+        mockPrisma.payment.delete.mockResolvedValue(creditPaymentForDelete);
+        mockPrisma.creditNoteAllocation.findFirst.mockResolvedValue({
+          id: 'alloc1',
+          creditNoteId: CREDIT_NOTE_ID,
+          appliedToInvoiceId: INVOICE_ID,
+          amount: 2000,
+        });
+        mockPrisma.parentCredit.findFirst.mockResolvedValue({
+          id: 'cr1',
+          creditNoteId: CREDIT_NOTE_ID,
+          amountOriginal: 5000,
+          amountRemaining: 3000,
+        });
+        mockPrisma.creditApplication.findFirst.mockResolvedValue({ id: 'app1' });
+      }
+
+      it('recrédite le solde de l\'avoir', async () => {
+        setupCreditDeleteMocks(admin.mockPrisma);
+
+        await admin.caller.payments.delete({ id: PAYMENT_ID });
+
+        expect(admin.mockPrisma.parentCredit.update).toHaveBeenCalledWith({
+          where: { id: 'cr1' },
+          data: { amountRemaining: 5000 },
+        });
+      });
+
+      it('supprime allocation et ligne d\'historique', async () => {
+        setupCreditDeleteMocks(admin.mockPrisma);
+
+        await admin.caller.payments.delete({ id: PAYMENT_ID });
+
+        expect(admin.mockPrisma.creditNoteAllocation.delete).toHaveBeenCalledWith({
+          where: { id: 'alloc1' },
+        });
+        expect(admin.mockPrisma.creditApplication.delete).toHaveBeenCalledWith({
+          where: { id: 'app1' },
+        });
+      });
+
+      it('restitue le crédit AVANT de supprimer le paiement', async () => {
+        // L'ordre compte : la restitution lit creditNoteId et invoiceId sur le
+        // paiement, qui doit donc exister encore.
+        setupCreditDeleteMocks(admin.mockPrisma);
+
+        await admin.caller.payments.delete({ id: PAYMENT_ID });
+
+        const restoreOrder = admin.mockPrisma.parentCredit.update.mock.invocationCallOrder[0];
+        const deleteOrder = admin.mockPrisma.payment.delete.mock.invocationCallOrder[0];
+        expect(restoreOrder).toBeLessThan(deleteOrder);
+      });
+
+      it('ne touche à aucun crédit pour un paiement classique', async () => {
+        setupDeleteMocks(admin.mockPrisma);
+
+        await admin.caller.payments.delete({ id: PAYMENT_ID });
+
+        expect(admin.mockPrisma.creditNoteAllocation.findFirst).not.toHaveBeenCalled();
+        expect(admin.mockPrisma.parentCredit.update).not.toHaveBeenCalled();
+      });
+    });
 
     it('should delete a payment and recalculate invoice', async () => {
       setupDeleteMocks(admin.mockPrisma);


### PR DESCRIPTION
Traite TD-003. Le périmètre s'est élargi au traitement : ce qui était noté P3 (« la suppression d'un paiement par avoir ne reprend pas l'allocation ») recouvrait un défaut P2 avec un impact comptable réel.

## Le défaut

Le solde d'un avoir avait **deux représentations**, mises à jour par des chemins différents :

| Vue | Alimentée par | Lue par |
|---|---|---|
| `ABS(total_amount) − SUM(credit_note_allocations)` | règlement manuel (`payments.create`) | contrôle de solde du règlement manuel |
| `ParentCredit.amountRemaining` | imputation automatique seule | FIFO de `applyAvailableCreditsToInvoice` |

Le chemin manuel ne décrémentait **jamais** `amountRemaining`. Un avoir consommé à la main restait donc « plein » aux yeux du FIFO, qui pouvait le réimputer sur une facture suivante.

Scénario : avoir de 5 000 appliqué manuellement sur la facture A, puis facture B validée → 5 000 réimputés. Le compte **4191 est débité de 10 000 pour 5 000 crédités** — déséquilibre de fond au FEC.

Le défaut était dormant avant US-FACT-02 : tant que personne ne lisait `amountRemaining`, sa dérive était sans conséquence. C'est l'imputation automatique livrée dans la PR #15 qui l'a rendu exploitable.

## Le correctif

- **`payments.create`** décrémente `amountRemaining` (plancher à 0) et écrit une `CreditApplication`, pour que l'historique de consommation soit uniforme quel que soit le chemin d'imputation.
  Aucun nouveau `throw` n'est introduit : le garde-fou du chemin manuel reste le solde calculé sur les allocations, comportement strictement inchangé. Un écart hérité ne peut donc pas bloquer une saisie légitime.
- **`payments.delete`** appelle `restoreCreditOnPaymentDeletion()` **avant** de supprimer le paiement (les identifiants sont lus dessus) : l'allocation est décrémentée ou supprimée, la ligne d'historique retirée, et `amountRemaining` recrédité **plafonné au montant initial** — une double suppression ne peut pas gonfler l'avoir.

L'invariant est documenté dans `CLAUDE.md` à côté de celui de US-FACT-02, pour que les deux chemins restent tenus à jour ensemble.

## Tests

15 nouveaux cas — 8 au niveau service (dont le cycle complet imputation → suppression → redisponibilité pour le FIFO) et 7 au niveau router, couvrant les deux chemins et l'ordre restitution-avant-suppression.

Ils ont été **vérifiés en échec sans le correctif** : en neutralisant l'appel de restitution, 3 tests router passent au rouge. Ils testent bien le comportement, pas le vide.

- `pnpm typecheck` — 0 erreur
- `pnpm lint` — 0 erreur
- `pnpm test` — **951 tests verts** (+15)

## Action de données à prévoir

Les avoirs consommés à la main **avant** ce correctif peuvent porter un `amount_remaining` surévalué.

`prisma/migrations-manual/2026-08-10-diagnostic-solde-avoirs.sql` fournit une requête **en lecture seule** listant les écarts. Aucune ligne renvoyée signifie qu'il n'y a rien à reprendre. La requête de réalignement figure dans le même fichier mais reste **commentée** : une correction de données doit être décidée après lecture des écarts, un écart pouvant aussi signaler une saisie hors application.

Volume attendu proche de zéro — les paiements réels sont quasi inexistants en prod à ce jour (cf. TD-002). Aucune écriture comptable n'est concernée par ce réalignement : le compte 4191 est alimenté par les écritures BQ, que rien ici ne touche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ndgYA86mBA8DvA5ASB8FR

---
_Generated by [Claude Code](https://claude.ai/code/session_014ndgYA86mBA8DvA5ASB8FR)_