### PR TITLE
TD-006/007/008 — blobs orphelins, PDF d'avoir câblé, envoi d'email implémenté

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,9 @@ POSTGRES_URL_NON_POOLING=postgresql://[user]:[password]@[endpoint].[region].aws.
 # Vercel Blob (PDF des factures, futurs uploads)
 # Token auto-injecté par Vercel quand le store Blob est connecté au projet
 BLOB_READ_WRITE_TOKEN=vercel_blob_rw_...
+
+# Envoi d'emails transactionnels (facture/devis au parent) — Resend
+# Absent = l'application le dit explicitement et désactive les boutons d'envoi,
+# elle ne casse pas. L'expéditeur (nom, adresse, reply-to) se règle dans
+# /dashboard/admin/settings, section Email.
+RESEND_API_KEY=re_...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
 
 ## [Unreleased]
 
+### Added — TD-007 : le PDF d'avoir est enfin accessible (2026-08-10)
+- **Le document existait, personne ne pouvait l'obtenir.** `CreditNotePDF` était
+  complet et testé, mais sans procédure ni bouton. `creditNotes.generatePDF`
+  reprend la chaîne de la facture (settings partagées, archivage Blob, `pdfUrl`
+  mémorisé) et le PDF se télécharge depuis la fiche de l'avoir comme depuis la
+  liste.
+- **Montants au bon signe** : les montants d'un avoir sont stockés négatifs et
+  le document pose lui-même le « - » — la procédure transmet des valeurs
+  absolues, sans quoi le PDF aurait affiché `--12 000 XPF`.
+
+### Fixed — TD-008 : l'envoi par email fonctionne (2026-08-10)
+- **Deux boutons proposaient une action qui échouait à tous les coups.**
+  `invoices.sendEmail` levait une `TRPCError` de code `'NOT_IMPLEMENTED' as any`
+  — un code absent de l'énumération tRPC, que le `as any` cachait au
+  compilateur. L'envoi est désormais réellement implémenté : la facture (ou le
+  **devis**, tant qu'elle est en brouillon) part au parent avec son PDF en pièce
+  jointe.
+- **La pièce jointe ne peut pas diverger du PDF téléchargeable** : la génération
+  est extraite dans un service partagé par les deux chemins.
+- **Erreurs honnêtes** : environnement sans clé d'envoi → `PRECONDITION_FAILED`
+  avec un message explicite ; client sans adresse → `BAD_REQUEST` ; refus du
+  fournisseur → statut et motif remontés. `settings.isEmailConfigured` permet
+  aux écrans de désactiver le bouton plutôt que de laisser l'utilisateur
+  découvrir l'échec.
+
+### Fixed — TD-006 : blobs orphelins (2026-08-10)
+- **Un document supprimé restait téléchargeable.** `deleteFromStorage` n'était
+  appelé nulle part : supprimer un document enfant, un document personnel ou le
+  logo retirait la ligne en base sans supprimer le fichier, qui restait
+  accessible par son URL publique — et facturé. Les trois chemins (plus le
+  remplacement du logo) suppriment maintenant l'objet.
+- **En best effort, dans le bon ordre** : la suppression métier fait autorité ;
+  un store injoignable est tracé mais ne fait pas échouer l'opération, et ne
+  ressuscite pas un document que l'utilisateur croit supprimé.
+
 ### Fixed — TD-004 : pied de page des PDF (2026-08-10)
 - **Trois documents pouvaient écrire sous leur pied de page.** Le défaut
   remonté en recette sur la facture (US-FACT-01-bis) était structurel : le pied

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,31 @@ recette : US-UX-03 puis US-FACT-01-bis). Ajouter aussi le nouveau document a
 `test/unit/pdf-footer-overlap.spec.tsx` — le defaut n'apparait qu'au calcul de
 mise en page, un test d'arbre React ne le voit pas.
 
+### PDF d'avoir — montants en valeur absolue
+Un avoir stocke ses montants **negatifs** en base, mais `CreditNotePDF` pose
+lui-meme le signe « - » devant chaque valeur. `creditNotes.generatePDF` transmet
+donc des `Math.abs(...)` — sinon le document affiche `--12 000 XPF`. Ne pas
+"corriger" ces `Math.abs` sans regarder le composant.
+
+### Supprimer un fichier : la ligne ET le blob (TD-006)
+Toute suppression d'un enregistrement qui porte une URL de fichier
+(`ChildDocument.fileUrl`, `StaffDocument.fileUrl`, `organization.logo_url`) doit
+appeler `deleteFromStorageBestEffort(url, contexte)` **apres** l'ecriture en
+base. Deux regles :
+- la base d'abord — sinon un echec de suppression en base laisse une ligne qui
+  pointe vers un objet disparu ;
+- best effort — un store injoignable est trace, jamais propage : un document que
+  l'utilisateur a supprime ne doit pas ressusciter parce que Vercel Blob a
+  hoquete.
+
+### Envoi d'email (TD-008)
+`server/services/email.service.ts` est le seul point d'envoi (API REST Resend).
+La cle vit dans l'environnement (`RESEND_API_KEY`), l'identite d'expedition dans
+les settings `email`. Un environnement sans cle n'est pas un bug : les
+procedures levent `PRECONDITION_FAILED` et les ecrans desactivent le bouton via
+`settings.isEmailConfigured`. Ne jamais inventer de code d'erreur tRPC — c'est
+exactement ce que faisait le `'NOT_IMPLEMENTED' as any` supprime par TD-008.
+
 ### Un enfant a toujours au moins un parent
 Invariant porte par un **trigger legacy** de la BDD (absent du depot, donc
 invisible des tests mockes) : supprimer une ligne `children_parents` qui
@@ -170,7 +195,7 @@ Pour chaque router :
 ## Documents
 
 - `docs/deploiement.md` — topologie Vercel/Neon, vars d'env, procedure de migration, incident 2025-11.
-- `docs/dette-technique.md` — registre de dette (TD-001 typage any des mappers OPEN ; TD-005 trigger legacy « dernier parent » absent du depot OPEN ; TD-002 factures legacy 0 XPF DONE ; TD-003 divergence des deux vues du solde d'un avoir DONE ; TD-004 reserve du pied de page PDF DONE ; TD-A2 couverture PDF facture DONE).
+- `docs/dette-technique.md` — registre de dette (TD-001 typage any des mappers OPEN ; TD-005 trigger legacy « dernier parent » absent du depot OPEN ; TD-002 factures legacy 0 XPF DONE ; TD-003 divergence des deux vues du solde d'un avoir DONE ; TD-004 reserve du pied de page PDF DONE ; TD-006 blobs orphelins DONE ; TD-007 PDF d'avoir cable DONE ; TD-008 envoi d'email implemente DONE ; TD-A2 couverture PDF facture DONE).
 - `docs/stories/BACKLOG.md` — backlog produit + **backlog MIKADO livre le 2026-08-09** (7 US, arbitrages US-FACT-02 tranches) + **retours de recette livres le 2026-08-10** (4 US : PDF facture, selecteur d'avoir, suppression de parent).
 - `docs/test-evidence/recette-v2.0.1/` — recette visuelle Playwright (19/19 PASS, `pnpm recette`) + rapport de preuve.
 - `CHANGELOG.md` — journal des livraisons (v2.0.0 premiere prod de la refonte + v2.0.1 correctifs campagne smoke, 2026-07-06).

--- a/components/admin/credit-notes/admin-credit-notes-table-client.tsx
+++ b/components/admin/credit-notes/admin-credit-notes-table-client.tsx
@@ -71,6 +71,22 @@ export function AdminCreditNotesTableClient() {
     },
   });
 
+  // Mutation de génération du PDF (TD-007) : archive le document puis l'ouvre.
+  const generatePDFMutation = trpc.creditNotes.generatePDF.useMutation({
+    onSuccess: (result) => {
+      toast.success("PDF de l'avoir généré avec succès");
+      utils.creditNotes.list.invalidate();
+      router.refresh();
+      if (result?.pdfUrl) {
+        window.open(result.pdfUrl, '_blank');
+      }
+    },
+    onError: (err) => {
+      setError(err.message || 'Erreur lors de la génération du PDF');
+      toast.error(err.message || 'Erreur lors de la génération du PDF');
+    },
+  });
+
   // Mutation de mise à jour de statut
   const updateStatusMutation = trpc.creditNotes.updateStatus.useMutation({
     onSuccess: () => {
@@ -121,6 +137,10 @@ export function AdminCreditNotesTableClient() {
             onDelete={setDeletingItem}
             onUpdateStatus={(item: AdminCreditNoteType, status: 'SENT' | 'CANCELLED') => {
               setUpdatingStatus({ item, status });
+            }}
+            onGeneratePDF={(item: AdminCreditNoteType) => {
+              setError(null);
+              generatePDFMutation.mutate({ id: item.id });
             }}
           />
         ),

--- a/components/admin/credit-notes/columns.tsx
+++ b/components/admin/credit-notes/columns.tsx
@@ -14,6 +14,7 @@ import {
   CheckCircle,
   XCircle,
   Trash2,
+  Download,
 } from 'lucide-react';
 import Link from 'next/link';
 import { StatusBadge } from '@/components/shared/status-badge';
@@ -32,6 +33,8 @@ export type AdminCreditNoteType = {
   notes: string | null;
   status: 'DRAFT' | 'SENT' | 'CANCELLED';
   isFutureCredit: boolean;
+  /** URL du PDF archivé, `null` tant qu'il n'a pas été généré (TD-007). */
+  pdfUrl: string | null;
   originalInvoice: {
     invoiceNumber: string;
     totalAmount: number;
@@ -147,6 +150,7 @@ export const adminCreditNoteColumns: ColumnDef<AdminCreditNoteType>[] = [
           item={row.original}
           onDelete={() => {}}
           onUpdateStatus={() => {}}
+          onGeneratePDF={() => {}}
         />
       );
     },
@@ -161,13 +165,25 @@ interface AdminCreditNoteActionsProps {
   item: AdminCreditNoteType;
   onDelete?: (item: AdminCreditNoteType) => void;
   onUpdateStatus?: (item: AdminCreditNoteType, status: 'SENT' | 'CANCELLED') => void;
+  /** Demande la génération du PDF quand l'avoir n'en a pas encore (TD-007). */
+  onGeneratePDF?: (item: AdminCreditNoteType) => void;
 }
 
 export function AdminCreditNoteActions({
   item,
   onDelete,
   onUpdateStatus,
+  onGeneratePDF,
 }: AdminCreditNoteActionsProps) {
+  const handleDownloadPDF = () => {
+    // PDF déjà archivé : téléchargement direct, sinon on le génère d'abord.
+    if (item.pdfUrl) {
+      window.open(item.pdfUrl, '_blank');
+    } else {
+      onGeneratePDF?.(item);
+    }
+  };
+
   return (
     <div className="text-right">
       <DropdownMenu>
@@ -183,6 +199,11 @@ export function AdminCreditNoteActions({
               <Eye className="mr-2 h-4 w-4" />
               Voir détails
             </Link>
+          </DropdownMenuItem>
+
+          <DropdownMenuItem onClick={handleDownloadPDF}>
+            <Download className="mr-2 h-4 w-4" />
+            Télécharger le PDF
           </DropdownMenuItem>
 
           {item.status === 'DRAFT' && (

--- a/components/admin/credit-notes/credit-note-actions.tsx
+++ b/components/admin/credit-notes/credit-note-actions.tsx
@@ -21,7 +21,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { CheckCircle, XCircle, Trash2, MoreHorizontal, Loader2 } from 'lucide-react';
+import { CheckCircle, XCircle, Trash2, MoreHorizontal, Loader2, Download } from 'lucide-react';
 import { useDashboardBasePath } from '@/lib/hooks/use-dashboard-base-path';
 
 interface CreditNote {
@@ -29,6 +29,8 @@ interface CreditNote {
   creditNoteNumber: string;
   status: 'DRAFT' | 'SENT' | 'CANCELLED';
   isFutureCredit: boolean;
+  /** URL du PDF archivé, `null` tant qu'il n'a pas été généré (TD-007). */
+  pdfUrl: string | null;
 }
 
 interface CreditNoteActionsProps {
@@ -51,6 +53,20 @@ export function CreditNoteActions({ creditNote }: CreditNoteActionsProps) {
     onError: (error) => {
       toast.error(error.message || 'Erreur lors de la mise à jour');
       setStatusDialogOpen(false);
+    },
+  });
+
+  // TD-007 : génération/archivage du PDF de l'avoir, puis ouverture.
+  const generatePDFMutation = trpc.creditNotes.generatePDF.useMutation({
+    onSuccess: (data) => {
+      toast.success("PDF de l'avoir généré avec succès");
+      router.refresh();
+      if (data?.pdfUrl) {
+        window.open(data.pdfUrl, '_blank');
+      }
+    },
+    onError: (error) => {
+      toast.error(error.message || 'Erreur lors de la génération du PDF');
     },
   });
 
@@ -81,6 +97,15 @@ export function CreditNoteActions({ creditNote }: CreditNoteActionsProps) {
     deleteMutation.mutate({ id: creditNote.id });
   };
 
+  const handleDownloadPDF = () => {
+    // PDF déjà archivé : on l'ouvre directement, sans régénérer.
+    if (creditNote.pdfUrl) {
+      window.open(creditNote.pdfUrl, '_blank');
+      return;
+    }
+    generatePDFMutation.mutate({ id: creditNote.id });
+  };
+
   const getStatusActionLabel = (status: 'SENT' | 'CANCELLED') => {
     switch (status) {
       case 'SENT':
@@ -93,6 +118,20 @@ export function CreditNoteActions({ creditNote }: CreditNoteActionsProps) {
   return (
     <>
       <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleDownloadPDF}
+          disabled={generatePDFMutation.isPending}
+        >
+          {generatePDFMutation.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="mr-2 h-4 w-4" />
+          )}
+          Télécharger le PDF
+        </Button>
+
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="icon">

--- a/components/admin/invoices/admin-invoices-table-client.tsx
+++ b/components/admin/invoices/admin-invoices-table-client.tsx
@@ -95,10 +95,15 @@ export function AdminInvoicesTableClient() {
     },
   });
 
+  // TD-008 : état de la configuration email — le dialogue de confirmation le
+  // dit explicitement plutôt que de laisser l'envoi échouer.
+  const { data: emailStatus } = trpc.settings.isEmailConfigured.useQuery();
+  const emailConfigured = emailStatus?.configured ?? true;
+
   // Mutation d'envoi email
   const sendEmailMutation = trpc.invoices.sendEmail.useMutation({
-    onSuccess: () => {
-      toast.success('Email envoyé avec succès');
+    onSuccess: (data) => {
+      toast.success(`Email envoyé à ${data.sentTo}`);
       setSendingEmailItem(null);
       utils.invoices.list.invalidate();
       router.refresh();
@@ -303,6 +308,12 @@ export function AdminInvoicesTableClient() {
               Numéro : <strong>{sendingEmailItem?.invoiceNumber}</strong>
               <br />
               Destinataire : <strong>{sendingEmailItem?.parent.email}</strong>
+              {!emailConfigured && (
+                <div className="mt-4 rounded-lg bg-yellow-50 p-3 text-yellow-900">
+                  <strong>Envoi indisponible :</strong> la configuration email de
+                  l'environnement est incomplète. Contactez l'administrateur.
+                </div>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -311,7 +322,7 @@ export function AdminInvoicesTableClient() {
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleSendEmail}
-              disabled={sendEmailMutation.isPending}
+              disabled={sendEmailMutation.isPending || !emailConfigured}
             >
               {sendEmailMutation.isPending && (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/components/admin/invoices/invoice-details.tsx
+++ b/components/admin/invoices/invoice-details.tsx
@@ -123,9 +123,15 @@ export function InvoiceDetails({ invoice }: { invoice: Invoice }) {
     },
   });
 
+  // TD-008 : l'envoi est réellement branché, mais dépend d'une configuration
+  // d'environnement. On interroge son état pour ne pas proposer un bouton qui
+  // échouerait à coup sûr.
+  const { data: emailStatus } = trpc.settings.isEmailConfigured.useQuery();
+  const emailConfigured = emailStatus?.configured ?? true;
+
   const sendEmailMutation = trpc.invoices.sendEmail.useMutation({
-    onSuccess: () => {
-      toast.success('Facture envoyée par email au parent');
+    onSuccess: (data) => {
+      toast.success(`Facture envoyée par email à ${data.sentTo}`);
       utils.invoices.getById.invalidate({ id: invoice.id });
       setIsSendingEmail(false);
       router.refresh();
@@ -262,7 +268,12 @@ export function InvoiceDetails({ invoice }: { invoice: Invoice }) {
                 variant="outline"
                 size="sm"
                 onClick={handleSendEmail}
-                disabled={isSendingEmail || invoice.status === 'DRAFT'}
+                disabled={isSendingEmail || invoice.status === 'DRAFT' || !emailConfigured}
+                title={
+                  emailConfigured
+                    ? undefined
+                    : "Envoi d'email non configuré sur cet environnement"
+                }
               >
                 {isSendingEmail ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -20,7 +20,12 @@
 | `AUTH_SECRET` | NextAuth v5 — **obligatoire**, fail-closed au boot en prod |
 | `POSTGRES_PRISMA_URL` | URL poolée pgbouncer — runtime Prisma (`schema.prisma url`) |
 | `POSTGRES_URL_NON_POOLING` | Connexion directe — migrations / `prisma migrate diff` (`directUrl`) |
-| `BLOB_READ_WRITE_TOKEN` | Upload des PDF de factures |
+| `BLOB_READ_WRITE_TOKEN` | Upload et suppression des PDF (factures, avoirs, documents) |
+| `RESEND_API_KEY` | Envoi des factures/devis par email (TD-008) — **optionnel** : sans elle, les écrans désactivent l'envoi et l'expliquent |
+
+L'identité d'expédition des emails (nom, adresse, reply-to) n'est **pas** une
+variable d'environnement : elle se règle dans /dashboard/admin/settings, section
+Email. Seul le domaine d'envoi doit être vérifié côté Resend.
 
 Vars legacy présentes mais inutilisées par le code : `NEXTAUTH_*`, `STACK_*`,
 `PG*`, `NEON_PROJECT_ID`, `DATABASE_URL` — nettoyage possible après stabilité.

--- a/docs/dette-technique.md
+++ b/docs/dette-technique.md
@@ -125,6 +125,88 @@ la ligne haute est à y=61,7).
 n'existe qu'après calcul de mise en page. Tout nouveau document PDF doit donc
 être ajouté à ce spec, faute de quoi il n'est pas couvert.
 
+## TD-006 — Blobs orphelins : `deleteFromStorage` jamais appelé — P2 — DONE (2026-08-10)
+
+**Constat (2026-08-10)** : `lib/storage/blob-storage.ts` exportait
+`deleteFromStorage` sans qu'aucun appelant ne l'utilise. Toute suppression d'un
+document enfant, d'un document personnel ou du logo retirait la ligne en base
+sans supprimer l'objet correspondant sur Vercel Blob. Le remplacement du logo
+avait le même effet.
+
+**Risque** : les fichiers restaient **accessibles par leur URL publique après
+leur suppression fonctionnelle** (un certificat médical « supprimé » reste
+lisible de quiconque a gardé le lien) — et continuaient d'être facturés.
+
+**✅ Résolu (2026-08-10)** :
+- `deleteFromStorageBestEffort(url, contexte)` ajouté au module de stockage :
+  supprime l'objet, **avale** l'erreur du store (log `console.error`) et
+  retourne un booléen. La suppression métier fait autorité — un store
+  injoignable ne doit pas ressusciter un document que l'utilisateur a supprimé,
+  et l'ordre inverse (blob d'abord) laisserait une ligne pointant vers le vide.
+- Câblé dans `childDocuments.delete`, `staffDocuments.delete`,
+  `settings.deleteLogoUrl` et `settings.setLogoUrl` (ancien logo remplacé, sauf
+  ré-enregistrement de la même URL).
+- `deleteFromStorage` échoue désormais explicitement si `BLOB_READ_WRITE_TOKEN`
+  est absent, comme `uploadToStorage` le faisait déjà.
+- Tests : `test/unit/blob-storage.spec.ts` (contrat best-effort) et couverture
+  des trois chemins d'appel dans les specs des routers concernés.
+
+**Reste (action d'exploitation)** : les blobs déjà orphelins d'avant ce
+correctif ne sont pas rattrapés par le code — inventaire et purge à faire une
+fois sur le store.
+
+## TD-007 — PDF d'avoir complet mais non câblé — P2 — DONE (2026-08-10)
+
+**Constat (2026-08-10)** : `lib/pdf/credit-note-pdf.tsx` était complet, corrigé
+par TD-004 et couvert par `pdf-footer-overlap.spec.tsx`, mais aucun point
+d'entrée ne l'appelait : ni procédure tRPC, ni bouton. Une fonctionnalité prête
+à 90 %, pas de la dette à jeter.
+
+**✅ Résolu (2026-08-10)** :
+- `creditNotes.generatePDF` (staff) reprend la chaîne de `invoices.generatePDF` :
+  settings PDF partagées, rendu, archivage sur le store Blob sous
+  `credit-notes/{numéro}-{id}.pdf`, `pdfUrl` mémorisé sur la ligne.
+- **Signe des montants** : les montants d'un avoir sont stockés négatifs alors
+  que le document pose lui-même le « - » devant chaque valeur — la procédure
+  transmet donc des valeurs absolues, sinon le PDF afficherait `--12 000 XPF`.
+  Un test verrouille ce point.
+- Un avoir autonome (sans facture d'origine) affiche « Aucune » en face de
+  « Facture concernée » plutôt qu'un champ vide.
+- UI : bouton « Télécharger le PDF » sur la fiche de l'avoir et entrée
+  correspondante dans le menu de la liste — PDF déjà archivé ouvert directement,
+  généré à la volée sinon (même comportement que la facture).
+
+## TD-008 — `invoices.sendEmail` levait une erreur inexistante — P1 — DONE (2026-08-10)
+
+**Constat (2026-08-10)** : la procédure levait inconditionnellement une
+`TRPCError` de code `'NOT_IMPLEMENTED' as any` — code absent de l'énumération
+tRPC, d'où le `as any` qui masquait le problème au compilateur. Elle n'était pas
+morte : **deux boutons visibles** l'appelaient (« Envoyer par email » sur la
+fiche facture, « Envoyer le devis » dans la liste). L'application proposait donc
+une action qui échouait à tous les coups.
+
+**✅ Résolu (2026-08-10)** :
+- `server/services/email.service.ts` — envoi transactionnel via l'API REST de
+  Resend (`fetch`, aucun SDK dans le bundle serverless). La **clé** vient de
+  l'environnement (`RESEND_API_KEY`, comme tout secret), l'**identité
+  d'expédition** des settings `email` déjà administrables.
+- `server/services/invoice-pdf.service.ts` — la génération du PDF de facture est
+  extraite du router pour que l'envoi joigne **exactement** le document
+  téléchargeable (même requête, même rendu, même objet archivé).
+- `invoices.sendEmail` envoie la facture — ou le **devis**, tant qu'elle est en
+  brouillon — au parent, PDF en pièce jointe, et retourne le destinataire.
+  Erreurs typées : `PRECONDITION_FAILED` si l'environnement n'a pas de clé,
+  `BAD_REQUEST` si le client n'a pas d'adresse, `INTERNAL_SERVER_ERROR` avec le
+  statut et le corps renvoyés par le fournisseur.
+- `settings.isEmailConfigured` expose l'état de configuration (booléen +
+  adresse d'expédition, aucun secret) : le bouton de la fiche est désactivé et
+  la boîte de dialogue de la liste explique l'indisponibilité au lieu de laisser
+  l'envoi échouer.
+
+**Prérequis d'exploitation** : renseigner `RESEND_API_KEY` sur Vercel et
+vérifier le domaine d'envoi côté Resend (voir `docs/deploiement.md`). Sans
+cela, l'application ne casse pas — elle dit que l'envoi est indisponible.
+
 ## TD-005 — Trigger legacy « dernier parent » absent du dépôt — P2 — OPEN
 
 **Constat (2026-08-10, US-FAM-01/02)** : l'invariant « un enfant a toujours au

--- a/lib/storage/blob-storage.ts
+++ b/lib/storage/blob-storage.ts
@@ -30,5 +30,46 @@ export async function uploadToStorage(
 }
 
 export async function deleteFromStorage(url: string): Promise<void> {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error(
+      'Vercel Blob non configuré. BLOB_READ_WRITE_TOKEN absent — connecter le store Blob au projet sur Vercel.',
+    );
+  }
+
   await del(url);
+}
+
+/**
+ * Supprime un objet du store en « best effort » (TD-006).
+ *
+ * La suppression fonctionnelle (ligne en base) fait autorité : si le store est
+ * injoignable, mal configuré ou que l'objet a déjà disparu, on ne fait PAS
+ * échouer la mutation appelante — on trace et on continue. L'inverse
+ * (suppression du blob avant la base, ou rollback sur échec blob) laisserait
+ * l'utilisateur devant un document qu'il croit supprimé et qui réapparaît.
+ *
+ * @param url URL publique du blob, telle que stockée en base (`fileUrl`,
+ *            `logo_url`…). Une valeur vide/nulle est ignorée silencieusement.
+ * @param context libellé court utilisé dans le log d'échec (ex. `'document enfant'`)
+ * @returns `true` si l'objet a été supprimé, `false` si l'appel a échoué ou
+ *          qu'il n'y avait rien à supprimer.
+ */
+export async function deleteFromStorageBestEffort(
+  url: string | null | undefined,
+  context: string,
+): Promise<boolean> {
+  if (!url) return false;
+
+  try {
+    await deleteFromStorage(url);
+    return true;
+  } catch (error) {
+    // Blob orphelin : facturé et toujours accessible par URL publique.
+    // Tracé pour permettre un nettoyage manuel, jamais propagé à l'appelant.
+    console.error(
+      `[blob-storage] Suppression du blob impossible (${context}) : ${url}`,
+      error,
+    );
+    return false;
+  }
 }

--- a/server/routers/child-documents.ts
+++ b/server/routers/child-documents.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { router, protectedProcedure } from '@/server/trpc/init';
+import { deleteFromStorageBestEffort } from '@/lib/storage/blob-storage';
 
 const childDocumentSchema = z.object({
   id: z.string().uuid(),
@@ -125,6 +126,11 @@ export const childDocumentsRouter = router({
         where: { id: input.documentId },
         data: { deletedAt: new Date() },
       });
+
+      // TD-006 : sans cet appel, le PDF reste accessible par son URL publique
+      // (et facturé) après sa suppression fonctionnelle. Best effort : un
+      // échec côté store ne doit pas ressusciter le document.
+      await deleteFromStorageBestEffort(doc.fileUrl, 'document enfant');
 
       return { success: true };
     }),

--- a/server/routers/credit-notes.ts
+++ b/server/routers/credit-notes.ts
@@ -44,6 +44,9 @@ const creditNoteSchema = z.object({
   status: creditNoteStatusEnum,
   isFutureCredit: z.boolean(),
   notes: z.string().nullable(),
+  // URL du PDF archivé sur le store Blob, `null` tant qu'il n'a pas été
+  // généré (TD-007).
+  pdfUrl: z.string().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -131,6 +134,7 @@ function mapCreditNoteWithDetails(cn: any) {
     status: cn.status as CreditNoteStatus,
     isFutureCredit: cn.isFutureCredit ?? false,
     notes: cn.notes,
+    pdfUrl: cn.pdfUrl ?? null,
     createdAt: cn.createdAt,
     updatedAt: cn.updatedAt,
     originalInvoice: cn.creditedInvoice
@@ -182,6 +186,7 @@ function mapCreditNote(cn: any) {
     status: cn.status as CreditNoteStatus,
     isFutureCredit: cn.isFutureCredit ?? false,
     notes: cn.notes,
+    pdfUrl: cn.pdfUrl ?? null,
     createdAt: cn.createdAt,
     updatedAt: cn.updatedAt,
   };
@@ -486,5 +491,89 @@ export const creditNotesRouter = router({
       });
 
       return { success: true };
+    }),
+
+  /**
+   * Génère (ou régénère) le PDF de l'avoir, l'archive sur le store Blob et
+   * mémorise son URL sur la ligne — même chaîne que `invoices.generatePDF`
+   * (TD-007 : le composant `CreditNotePDF` existait sans point d'entrée).
+   *
+   * Les montants sont stockés négatifs en base (avoir) alors que le document
+   * pose lui-même le signe « - » devant chaque montant : on lui passe donc des
+   * valeurs absolues, sinon le PDF afficherait « --12 000 XPF ».
+   */
+  generatePDF: staffProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .output(z.object({ success: z.boolean(), pdfUrl: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const creditNote = await ctx.prisma.invoice.findFirst({
+        where: { id: input.id, invoiceType: 'CREDIT_NOTE', deletedAt: null },
+        include: {
+          creditedInvoice: {
+            select: { invoiceNumber: true },
+          },
+          parent: {
+            select: {
+              firstName: true,
+              lastName: true,
+              email: true,
+              address: true,
+              city: true,
+              postalCode: true,
+            },
+          },
+          lines: {
+            select: {
+              description: true,
+              quantity: true,
+              unitPrice: true,
+              totalPrice: true,
+              totalHt: true,
+            },
+          },
+        },
+      });
+
+      if (!creditNote) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Avoir non trouvé' });
+      }
+
+      const { getPdfSettings } = await import('@/server/helpers/pdf-settings.helper');
+      const pdfSettings = await getPdfSettings(ctx.prisma);
+
+      const { generateCreditNotePDF } = await import('@/lib/pdf/credit-note-pdf');
+      const { uploadToStorage } = await import('@/lib/storage/blob-storage');
+
+      const pdfBuffer = await generateCreditNotePDF({
+        creditNoteNumber: creditNote.invoiceNumber,
+        issueDate: creditNote.issueDate,
+        // Un avoir peut être autonome (crédit commercial sans facture d'origine).
+        invoiceNumber: creditNote.creditedInvoice?.invoiceNumber ?? 'Aucune',
+        parent: creditNote.parent,
+        lines: creditNote.lines.map((l) => ({
+          description: l.description,
+          quantity: l.quantity,
+          unitPrice: Math.abs(toNum(l.unitPrice)),
+          totalPrice: Math.abs(toNum(l.totalHt ?? l.totalPrice)),
+        })),
+        totalAmount: Math.abs(toNum(creditNote.totalAmount)),
+        reason: creditNote.notes ?? '',
+        org: pdfSettings.org,
+        footerMention: pdfSettings.mentions.creditNote || undefined,
+      });
+
+      const pathname = `credit-notes/${creditNote.invoiceNumber}-${creditNote.id}.pdf`;
+
+      const { url } = await uploadToStorage(pdfBuffer, {
+        pathname,
+        contentType: 'application/pdf',
+      });
+
+      await ctx.prisma.invoice.update({
+        where: { id: creditNote.id },
+        data: { pdfUrl: url },
+      });
+
+      return { success: true, pdfUrl: url };
     }),
 });

--- a/server/routers/invoices.ts
+++ b/server/routers/invoices.ts
@@ -12,6 +12,7 @@ import { toNum } from '@/server/helpers/decimal';
 import { createInvoiceAccountingEntries } from '@/server/services/accounting.service';
 import { applyAvailableCreditsToInvoice } from '@/server/services/credit-application.service';
 import { generateInvoiceNumber } from '@/server/helpers/invoice-number';
+import { generateAndStoreInvoicePdf } from '@/server/services/invoice-pdf.service';
 
 type InvStatus = 'DRAFT' | 'SENT' | 'PAID' | 'OVERDUE' | 'CANCELLED' | 'CREDITED';
 
@@ -759,124 +760,106 @@ export const invoicesRouter = router({
     .input(z.object({ id: z.string().uuid() }))
     .output(z.object({ success: z.boolean(), pdfUrl: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      const invoice = await ctx.prisma.invoice.findFirst({
-        where: { id: input.id, deletedAt: null },
-        include: {
-          parent: {
-            select: {
-              firstName: true,
-              lastName: true,
-              email: true,
-              address: true,
-              city: true,
-              postalCode: true,
-            },
-          },
-          lines: {
-            where: { deletedAt: null },
-            select: {
-              description: true,
-              quantity: true,
-              unitPrice: true,
-              totalPrice: true,
-            },
-          },
-          payments: {
-            // Select whitelist : aucun champ sensible (référence bancaire,
-            // notes internes, opérateur de saisie) ne doit fuir dans le PDF.
-            select: {
-              amount: true,
-              paymentDate: true,
-              paymentMethod: {
-                select: { name: true },
-              },
-              // Numéro de l'avoir imputé, pour les règlements par avoir
-              // (US-FACT-02 — traçabilité sur la facture).
-              creditNote: {
-                select: { invoiceNumber: true },
-              },
-            },
-            orderBy: { paymentDate: 'asc' },
-          },
-        },
-      });
-      if (!invoice) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Facture non trouvée' });
+      const { pdfUrl } = await generateAndStoreInvoicePdf(ctx.prisma, input.id);
+      return { success: true, pdfUrl };
+    }),
+
+  /**
+   * Envoie la facture (ou le devis, tant qu'elle est en brouillon) au parent,
+   * PDF en pièce jointe (TD-008).
+   *
+   * Le PDF est régénéré à chaque envoi : la pièce jointe reflète donc l'état
+   * du document au moment de l'envoi, et l'URL archivée est rafraîchie au
+   * passage.
+   */
+  sendEmail: staffProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .output(z.object({ success: z.boolean(), sentTo: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const {
+        isEmailConfigured,
+        getEmailSender,
+        sendEmail: sendTransactionalEmail,
+        escapeHtml,
+      } = await import('@/server/services/email.service');
+
+      if (!isEmailConfigured()) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message:
+            "L'envoi d'email n'est pas configuré sur cet environnement (clé RESEND_API_KEY absente). Contactez l'administrateur.",
+        });
+      }
+
+      const { invoice, pdfBuffer } = await generateAndStoreInvoicePdf(
+        ctx.prisma,
+        input.id,
+      );
+
+      const recipient: string | null = invoice.parent?.email ?? null;
+      if (!recipient) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: "Ce client n'a pas d'adresse email : impossible de lui envoyer le document.",
+        });
       }
 
       const { getPdfSettings } = await import('@/server/helpers/pdf-settings.helper');
-      const pdfSettings = await getPdfSettings(ctx.prisma);
+      const [pdfSettings, sender] = await Promise.all([
+        getPdfSettings(ctx.prisma),
+        getEmailSender(ctx.prisma),
+      ]);
 
-      const logoSetting = await ctx.prisma.appSetting.findUnique({
-        where: { category_key: { category: 'organization', key: 'logo_url' } },
-        select: { value: true },
-      });
-      const logoUrl: string | undefined = (() => {
-        const raw = logoSetting?.value;
-        if (!raw) return undefined;
-        try {
-          const parsed = JSON.parse(raw);
-          return typeof parsed === 'string' ? parsed : undefined;
-        } catch {
-          return raw;
-        }
-      })();
+      // Un brouillon n'est pas encore une facture : c'est le devis que les
+      // écrans admin proposent d'envoyer (« Envoyer le devis »).
+      const isQuote = invoice.status === 'DRAFT';
+      const label = isQuote ? 'devis' : 'facture';
+      const orgName = pdfSettings.org.shortName || pdfSettings.org.name;
+      const amount = `${toNum(invoice.totalAmount).toLocaleString('fr-FR')} XPF`;
+      const dueDate = new Date(invoice.dueDate).toLocaleDateString('fr-FR');
+      const greeting = `${invoice.parent.firstName} ${invoice.parent.lastName}`.trim();
 
-      const { generateInvoicePDF } = await import('@/lib/pdf/invoice-pdf');
-      const { uploadToStorage } = await import('@/lib/storage/blob-storage');
+      const subject = isQuote
+        ? `Votre devis ${invoice.invoiceNumber} — ${orgName}`
+        : `Votre facture ${invoice.invoiceNumber} — ${orgName}`;
 
-      const pdfBuffer = await generateInvoicePDF({
-        invoiceNumber: invoice.invoiceNumber,
-        issueDate: invoice.issueDate,
-        dueDate: invoice.dueDate,
-        status: invoice.status as 'DRAFT' | 'SENT' | 'PAID' | 'OVERDUE' | 'CANCELLED',
-        parent: invoice.parent,
-        lines: invoice.lines.map((l) => ({
-          description: l.description,
-          quantity: l.quantity,
-          unitPrice: toNum(l.unitPrice),
-          totalPrice: toNum(l.totalPrice),
-        })),
-        payments: invoice.payments.map((p) => ({
-          amount: toNum(p.amount),
-          paymentDate: p.paymentDate,
-          paymentMethod: p.paymentMethod.name,
-          creditNoteNumber: p.creditNote?.invoiceNumber ?? null,
-        })),
-        subtotalHt: toNum(invoice.subtotalHt),
-        taxAmount: toNum(invoice.taxAmount),
-        taxRate: toNum(invoice.taxRate) * 100,
-        totalAmount: toNum(invoice.totalAmount),
-        paidAmount: toNum(invoice.paidAmount),
-        org: pdfSettings.org,
-        footerMention: pdfSettings.mentions.invoice || undefined,
-        logoUrl,
-      });
+      const lines = [
+        `Bonjour ${greeting},`,
+        isQuote
+          ? `Vous trouverez en pièce jointe votre devis ${invoice.invoiceNumber} d'un montant de ${amount}.`
+          : `Vous trouverez en pièce jointe votre facture ${invoice.invoiceNumber} d'un montant de ${amount}, à régler avant le ${dueDate}.`,
+        `Pour toute question, répondez simplement à cet email.`,
+        `Cordialement,`,
+        orgName,
+      ];
 
-      const pathname = `invoices/${invoice.invoiceNumber}-${invoice.id}.pdf`;
-
-      const { url } = await uploadToStorage(pdfBuffer, {
-        pathname,
-        contentType: 'application/pdf',
-      });
-
-      await ctx.prisma.invoice.update({
-        where: { id: invoice.id },
-        data: { pdfUrl: url },
+      await sendTransactionalEmail(
+        {
+          to: recipient,
+          subject,
+          text: lines.join('\n\n'),
+          html: lines
+            .map((line) => `<p>${escapeHtml(line)}</p>`)
+            .join('\n'),
+          attachments: [
+            {
+              filename: `${label}-${invoice.invoiceNumber}.pdf`,
+              content: pdfBuffer,
+            },
+          ],
+        },
+        sender,
+      ).catch((error: unknown) => {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message:
+            error instanceof Error
+              ? `Envoi impossible : ${error.message}`
+              : "Envoi impossible : erreur inconnue du fournisseur d'email.",
+        });
       });
 
-      return { success: true, pdfUrl: url };
-    }),
-
-  sendEmail: staffProcedure
-    .input(z.object({ id: z.string().uuid() }))
-    .output(z.object({ success: z.boolean() }))
-    .mutation(async ({ ctx, input }) => {
-      // TODO: Email sending will be implemented in Phase 3 (email setup)
-      throw new TRPCError({
-        code: 'NOT_IMPLEMENTED' as any,
-        message: "L'envoi d'email sera implémenté lors de la configuration email",
-      });
+      return { success: true, sentTo: recipient };
     }),
 
   fetchUnpaidRegistrations: staffProcedure

--- a/server/routers/settings.ts
+++ b/server/routers/settings.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { router, staffProcedure, adminProcedure } from '@/server/trpc/init';
 import type { AppSetting } from '@prisma/client';
+import { deleteFromStorageBestEffort } from '@/lib/storage/blob-storage';
 
 const settingCategories = z.enum([
   'organization', 'pricing', 'email', 'accounting', 'maintenance', 'documents',
@@ -10,6 +11,20 @@ type SettingCategory = z.infer<typeof settingCategories>;
 
 function mapSetting(s: AppSetting) {
   return { ...s, category: s.category as SettingCategory };
+}
+
+/**
+ * Lit la valeur stockée du logo (JSON-stringified, ou en clair pour les lignes
+ * legacy) et retourne l'URL, ou `undefined` si la valeur est absente/vide.
+ */
+function parseLogoValue(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === 'string' && parsed.trim() ? parsed : undefined;
+  } catch {
+    return value;
+  }
 }
 
 const settingSchema = z.object({
@@ -133,10 +148,42 @@ export const settingsRouter = router({
       return map;
     }),
 
+  /**
+   * Indique si l'envoi d'email est opérationnel sur cet environnement (TD-008).
+   *
+   * Consommé par les écrans de facturation pour ne pas proposer un envoi qui
+   * échouerait faute de configuration. Ne renvoie aucun secret : uniquement le
+   * booléen et l'adresse d'expédition affichable.
+   */
+  isEmailConfigured: staffProcedure
+    .output(z.object({ configured: z.boolean(), fromEmail: z.string().nullable() }))
+    .query(async ({ ctx }) => {
+      const { isEmailConfigured, getEmailSender } = await import(
+        '@/server/services/email.service'
+      );
+
+      const configured = isEmailConfigured();
+      if (!configured) {
+        return { configured: false, fromEmail: null };
+      }
+
+      const sender = await getEmailSender(ctx.prisma);
+      return { configured: true, fromEmail: sender.fromEmail };
+    }),
+
   setLogoUrl: adminProcedure
     .input(z.object({ url: z.string().url() }))
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
+      // TD-006 : le logo remplacé n'est plus référencé nulle part — son blob
+      // resterait facturé et public. On le lit AVANT l'upsert.
+      const previous = await ctx.prisma.appSetting.findUnique({
+        where: {
+          category_key: { category: 'organization', key: 'logo_url' },
+        },
+      });
+      const previousUrl = parseLogoValue(previous?.value);
+
       await ctx.prisma.appSetting.upsert({
         where: {
           category_key: { category: 'organization', key: 'logo_url' },
@@ -150,6 +197,11 @@ export const settingsRouter = router({
           value: JSON.stringify(input.url),
         },
       });
+
+      if (previousUrl && previousUrl !== input.url) {
+        await deleteFromStorageBestEffort(previousUrl, 'logo remplacé');
+      }
+
       return { success: true };
     }),
 
@@ -161,22 +213,27 @@ export const settingsRouter = router({
           category_key: { category: 'organization', key: 'logo_url' },
         },
       });
-      if (!setting?.value) return null;
-      try {
-        return typeof setting.value === 'string'
-          ? JSON.parse(setting.value)
-          : setting.value;
-      } catch {
-        return setting.value;
-      }
+      return parseLogoValue(setting?.value) ?? null;
     }),
 
   deleteLogoUrl: adminProcedure
     .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx }) => {
+      // TD-006 : lire l'URL avant de supprimer la ligne, sinon le blob devient
+      // introuvable côté application tout en restant public et facturé.
+      const setting = await ctx.prisma.appSetting.findUnique({
+        where: {
+          category_key: { category: 'organization', key: 'logo_url' },
+        },
+      });
+      const url = parseLogoValue(setting?.value);
+
       await ctx.prisma.appSetting.deleteMany({
         where: { category: 'organization', key: 'logo_url' },
       });
+
+      await deleteFromStorageBestEffort(url, 'logo supprimé');
+
       return { success: true };
     }),
 });

--- a/server/routers/staff-documents.ts
+++ b/server/routers/staff-documents.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { router, protectedProcedure } from '@/server/trpc/init';
+import { deleteFromStorageBestEffort } from '@/lib/storage/blob-storage';
 
 const staffDocumentSchema = z.object({
     id: z.string().uuid(),
@@ -98,6 +99,11 @@ export const staffDocumentsRouter = router({
                 where: { id: input.documentId },
                 data: { deletedAt: new Date() },
             });
+
+            // TD-006 : idem documents enfants — le blob doit suivre la ligne
+            // en base, sinon un document personnel supprimé reste lisible par
+            // quiconque connaît son URL.
+            await deleteFromStorageBestEffort(doc.fileUrl, 'document personnel');
 
             return { success: true };
         }),

--- a/server/services/email.service.ts
+++ b/server/services/email.service.ts
@@ -1,0 +1,174 @@
+/**
+ * Service d'envoi d'emails transactionnels (TD-008).
+ *
+ * Fournisseur : Resend, appelé via son API REST (`fetch`) — aucun SDK à
+ * embarquer dans le bundle serverless.
+ *
+ * Configuration en deux morceaux, volontairement séparés :
+ * - la **clé d'API** vient de l'environnement (`RESEND_API_KEY`), comme tout
+ *   secret du projet — elle n'a rien à faire dans `app_settings` ;
+ * - l'**identité d'expédition** (nom, adresse, reply-to) vient des settings
+ *   `email` administrables depuis /dashboard/admin/settings.
+ *
+ * Si la clé est absente, `isEmailConfigured()` retourne `false` et les
+ * appelants doivent le dire explicitement à l'utilisateur : une action qui
+ * échoue en silence (ou avec un code d'erreur inventé) est pire que pas
+ * d'action du tout.
+ */
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface EmailAttachment {
+  filename: string;
+  content: Buffer;
+}
+
+export interface SendEmailInput {
+  to: string;
+  subject: string;
+  /** Corps HTML. */
+  html: string;
+  /** Corps texte, pour les clients qui n'affichent pas le HTML. */
+  text?: string;
+  attachments?: EmailAttachment[];
+}
+
+export interface EmailSender {
+  fromName: string;
+  fromEmail: string;
+  replyTo?: string;
+}
+
+/** Interface minimale Prisma : suffit aux tests, compatible client étendu. */
+interface HasAppSettingFindMany {
+  appSetting: {
+    findMany: (args: {
+      where: { category: string };
+      select: { key: true; value: true };
+    }) => Promise<Array<{ key: string; value: string | null }>>;
+  };
+}
+
+// ============================================================================
+// CONFIGURATION
+// ============================================================================
+
+/**
+ * `true` si l'envoi d'email est opérationnel sur cet environnement.
+ * Exposé au front (`settings.isEmailConfigured`) pour que les boutons d'envoi
+ * ne proposent pas une action vouée à l'échec.
+ */
+export function isEmailConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY);
+}
+
+/** Parse un setting JSON-stringified (cf. router settings.update). */
+function parseSetting(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'string' && parsed.trim() ? parsed : undefined;
+  } catch {
+    return raw.trim() ? raw : undefined;
+  }
+}
+
+/**
+ * Lit l'identité d'expédition dans les settings `email`.
+ * Fallbacks alignés sur le seed (`prisma/seed.ts`).
+ */
+export async function getEmailSender(
+  prisma: HasAppSettingFindMany,
+): Promise<EmailSender> {
+  const rows = await prisma.appSetting.findMany({
+    where: { category: 'email' },
+    select: { key: true, value: true },
+  });
+
+  const map = new Map(rows.map((r) => [r.key, parseSetting(r.value)]));
+
+  return {
+    fromName: map.get('from_name') ?? 'ALVM',
+    fromEmail: map.get('from_email') ?? 'noreply@alvm.nc',
+    replyTo: map.get('reply_to'),
+  };
+}
+
+/**
+ * Échappe une chaîne destinée au corps HTML d'un email.
+ *
+ * Les données injectées viennent de la base (nom du client, numéro de pièce,
+ * nom de l'organisation) : elles sont saisies par des humains et peuvent
+ * contenir `&`, `<`, `"`… qui casseraient le rendu du message.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// ============================================================================
+// ENVOI
+// ============================================================================
+
+/**
+ * Envoie un email transactionnel.
+ *
+ * @throws si la clé d'API est absente ou si le fournisseur rejette l'envoi —
+ *         l'appelant (router tRPC) traduit en `TRPCError` avec un message
+ *         lisible par l'utilisateur.
+ */
+export async function sendEmail(
+  input: SendEmailInput,
+  sender: EmailSender,
+): Promise<{ id: string }> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Envoi d'email non configuré : RESEND_API_KEY absent de l'environnement.",
+    );
+  }
+
+  const response = await fetch(RESEND_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: `${sender.fromName} <${sender.fromEmail}>`,
+      to: [input.to],
+      ...(sender.replyTo ? { reply_to: sender.replyTo } : {}),
+      subject: input.subject,
+      html: input.html,
+      ...(input.text ? { text: input.text } : {}),
+      ...(input.attachments?.length
+        ? {
+            attachments: input.attachments.map((a) => ({
+              filename: a.filename,
+              content: a.content.toString('base64'),
+            })),
+          }
+        : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    // Le corps d'erreur Resend est du JSON `{ name, message }`, mais on ne peut
+    // pas en dépendre (proxy, 502 HTML…) : on retombe sur le texte brut.
+    const detail = await response.text().catch(() => '');
+    throw new Error(
+      `Le fournisseur d'email a refusé l'envoi (HTTP ${response.status}). ${detail}`.trim(),
+    );
+  }
+
+  const payload = (await response.json().catch(() => ({}))) as { id?: string };
+  return { id: payload.id ?? '' };
+}

--- a/server/services/invoice-pdf.service.ts
+++ b/server/services/invoice-pdf.service.ts
@@ -1,0 +1,148 @@
+/**
+ * Génération + archivage du PDF d'une facture.
+ *
+ * Extrait de `invoices.generatePDF` (TD-008) pour que l'envoi par email
+ * réutilise exactement la même chaîne : même requête (whitelist de select),
+ * même rendu, même objet archivé sur le store Blob. Une pièce jointe qui
+ * diverge du PDF téléchargeable serait un défaut invisible en test et
+ * embarrassant en production.
+ */
+
+import { TRPCError } from '@trpc/server';
+import { toNum } from '@/server/helpers/decimal';
+
+/**
+ * Client Prisma — compatible avec PrismaClient et les clients étendus
+ * (extension soft-delete, callback `$transaction`). Même convention que
+ * `credit-application.service.ts`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PrismaLike = any;
+
+export interface InvoicePdfResult {
+  /** Facture telle que lue pour le rendu (numéro, statut, parent, montants…). */
+  invoice: PrismaLike;
+  /** PDF rendu, utilisable directement en pièce jointe. */
+  pdfBuffer: Buffer;
+  /** URL publique de l'objet archivé, également mémorisée sur la facture. */
+  pdfUrl: string;
+}
+
+/**
+ * Rend le PDF de la facture, l'archive sur le store Blob et mémorise son URL.
+ *
+ * @throws TRPCError NOT_FOUND si la facture n'existe pas (ou est archivée)
+ */
+export async function generateAndStoreInvoicePdf(
+  prisma: PrismaLike,
+  invoiceId: string,
+): Promise<InvoicePdfResult> {
+  const invoice = await prisma.invoice.findFirst({
+    where: { id: invoiceId, deletedAt: null },
+    include: {
+      parent: {
+        select: {
+          firstName: true,
+          lastName: true,
+          email: true,
+          address: true,
+          city: true,
+          postalCode: true,
+        },
+      },
+      lines: {
+        where: { deletedAt: null },
+        select: {
+          description: true,
+          quantity: true,
+          unitPrice: true,
+          totalPrice: true,
+        },
+      },
+      payments: {
+        // Select whitelist : aucun champ sensible (référence bancaire,
+        // notes internes, opérateur de saisie) ne doit fuir dans le PDF.
+        select: {
+          amount: true,
+          paymentDate: true,
+          paymentMethod: {
+            select: { name: true },
+          },
+          // Numéro de l'avoir imputé, pour les règlements par avoir
+          // (US-FACT-02 — traçabilité sur la facture).
+          creditNote: {
+            select: { invoiceNumber: true },
+          },
+        },
+        orderBy: { paymentDate: 'asc' },
+      },
+    },
+  });
+
+  if (!invoice) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Facture non trouvée' });
+  }
+
+  const { getPdfSettings } = await import('@/server/helpers/pdf-settings.helper');
+  const pdfSettings = await getPdfSettings(prisma);
+
+  const logoSetting = await prisma.appSetting.findUnique({
+    where: { category_key: { category: 'organization', key: 'logo_url' } },
+    select: { value: true },
+  });
+  const logoUrl: string | undefined = (() => {
+    const raw = logoSetting?.value;
+    if (!raw) return undefined;
+    try {
+      const parsed = JSON.parse(raw);
+      return typeof parsed === 'string' ? parsed : undefined;
+    } catch {
+      return raw;
+    }
+  })();
+
+  const { generateInvoicePDF } = await import('@/lib/pdf/invoice-pdf');
+  const { uploadToStorage } = await import('@/lib/storage/blob-storage');
+
+  const pdfBuffer = await generateInvoicePDF({
+    invoiceNumber: invoice.invoiceNumber,
+    issueDate: invoice.issueDate,
+    dueDate: invoice.dueDate,
+    status: invoice.status as 'DRAFT' | 'SENT' | 'PAID' | 'OVERDUE' | 'CANCELLED',
+    parent: invoice.parent,
+    lines: invoice.lines.map((l: PrismaLike) => ({
+      description: l.description,
+      quantity: l.quantity,
+      unitPrice: toNum(l.unitPrice),
+      totalPrice: toNum(l.totalPrice),
+    })),
+    payments: invoice.payments.map((p: PrismaLike) => ({
+      amount: toNum(p.amount),
+      paymentDate: p.paymentDate,
+      paymentMethod: p.paymentMethod.name,
+      creditNoteNumber: p.creditNote?.invoiceNumber ?? null,
+    })),
+    subtotalHt: toNum(invoice.subtotalHt),
+    taxAmount: toNum(invoice.taxAmount),
+    taxRate: toNum(invoice.taxRate) * 100,
+    totalAmount: toNum(invoice.totalAmount),
+    paidAmount: toNum(invoice.paidAmount),
+    org: pdfSettings.org,
+    footerMention: pdfSettings.mentions.invoice || undefined,
+    logoUrl,
+  });
+
+  const pathname = `invoices/${invoice.invoiceNumber}-${invoice.id}.pdf`;
+
+  const { url } = await uploadToStorage(pdfBuffer, {
+    pathname,
+    contentType: 'application/pdf',
+  });
+
+  await prisma.invoice.update({
+    where: { id: invoice.id },
+    data: { pdfUrl: url },
+  });
+
+  return { invoice, pdfBuffer, pdfUrl: url };
+}

--- a/test/helpers/mock-prisma.ts
+++ b/test/helpers/mock-prisma.ts
@@ -33,6 +33,7 @@ export function createMockPrisma() {
     child: createModelMock(),
     childParent: createModelMock(),
     childDocument: createModelMock(),
+    staffDocument: createModelMock(),
     camp: createModelMock(),
     campDay: createModelMock(),
     attendance: createModelMock(),

--- a/test/unit/blob-storage.spec.ts
+++ b/test/unit/blob-storage.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * TD-006 — suppression des objets Vercel Blob.
+ *
+ * `deleteFromStorageBestEffort` est le point d'appel de tous les routers qui
+ * suppriment un fichier : il ne doit JAMAIS propager d'erreur (la suppression
+ * fonctionnelle en base fait autorité), mais il doit bien appeler le store.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const del = vi.fn();
+
+vi.mock('@vercel/blob', () => ({
+  put: vi.fn(),
+  del: (...args: unknown[]) => del(...args),
+}));
+
+import { deleteFromStorage, deleteFromStorageBestEffort } from '@/lib/storage/blob-storage';
+
+const URL_1 = 'https://store.public.blob.vercel-storage.com/child-documents/doc.pdf';
+
+describe('blob-storage — suppression (TD-006)', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    del.mockReset();
+    del.mockResolvedValue(undefined);
+    process.env.BLOB_READ_WRITE_TOKEN = 'vercel_blob_rw_test';
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+  });
+
+  describe('deleteFromStorage', () => {
+    it('supprime le blob', async () => {
+      await deleteFromStorage(URL_1);
+      expect(del).toHaveBeenCalledWith(URL_1);
+    });
+
+    it('échoue explicitement si le store n’est pas configuré', async () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN;
+
+      await expect(deleteFromStorage(URL_1)).rejects.toThrow('BLOB_READ_WRITE_TOKEN');
+      expect(del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteFromStorageBestEffort', () => {
+    it('supprime le blob et retourne true', async () => {
+      const result = await deleteFromStorageBestEffort(URL_1, 'document enfant');
+
+      expect(result).toBe(true);
+      expect(del).toHaveBeenCalledWith(URL_1);
+    });
+
+    it('n’appelle pas le store pour une URL absente', async () => {
+      expect(await deleteFromStorageBestEffort(null, 'document enfant')).toBe(false);
+      expect(await deleteFromStorageBestEffort(undefined, 'document enfant')).toBe(false);
+      expect(await deleteFromStorageBestEffort('', 'document enfant')).toBe(false);
+      expect(del).not.toHaveBeenCalled();
+    });
+
+    it('avale l’erreur du store et la trace (la suppression métier fait autorité)', async () => {
+      del.mockRejectedValue(new Error('Blob not found'));
+
+      const result = await deleteFromStorageBestEffort(URL_1, 'document enfant');
+
+      expect(result).toBe(false);
+      expect(consoleError).toHaveBeenCalled();
+      expect(String(consoleError.mock.calls[0]![0])).toContain(URL_1);
+    });
+
+    it('avale aussi l’absence de configuration du store', async () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN;
+
+      await expect(
+        deleteFromStorageBestEffort(URL_1, 'logo supprimé'),
+      ).resolves.toBe(false);
+    });
+  });
+});

--- a/test/unit/child-documents.spec.ts
+++ b/test/unit/child-documents.spec.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+
+// TD-006 : la suppression d'un document doit retirer le blob associé.
+const deleteFromStorageBestEffort = vi.fn().mockResolvedValue(true);
+vi.mock('@/lib/storage/blob-storage', () => ({
+  uploadToStorage: vi.fn(),
+  deleteFromStorage: vi.fn(),
+  deleteFromStorageBestEffort: (...args: unknown[]) =>
+    deleteFromStorageBestEffort(...args),
+}));
+
 import {
   createTestCaller,
   ADMIN_USER,
@@ -69,6 +79,8 @@ describe('childDocuments router', () => {
     admin = createTestCaller(ADMIN_USER);
     staff = createTestCaller(STAFF_USER);
     parent = createTestCaller(PARENT_USER);
+    deleteFromStorageBestEffort.mockClear();
+    deleteFromStorageBestEffort.mockResolvedValue(true);
   });
 
   // =========================================================================
@@ -362,6 +374,47 @@ describe('childDocuments router', () => {
         where: { id: DOC_ID_1 },
         data: { deletedAt: expect.any(Date) },
       });
+    });
+
+    // TD-006 — blobs orphelins
+    it('should delete the stored blob alongside the row', async () => {
+      admin.mockPrisma.childDocument.findFirst.mockResolvedValue(
+        makeDocument({ fileUrl: 'https://store.blob.vercel-storage.com/doc-1.pdf' }),
+      );
+      admin.mockPrisma.child.findFirst.mockResolvedValue(makeChildRecord());
+      admin.mockPrisma.childDocument.update.mockResolvedValue(
+        makeDocument({ deletedAt: new Date() }),
+      );
+
+      await admin.caller.childDocuments.delete({ documentId: DOC_ID_1 });
+
+      expect(deleteFromStorageBestEffort).toHaveBeenCalledWith(
+        'https://store.blob.vercel-storage.com/doc-1.pdf',
+        expect.any(String),
+      );
+    });
+
+    it('should still succeed when the blob store fails', async () => {
+      admin.mockPrisma.childDocument.findFirst.mockResolvedValue(makeDocument());
+      admin.mockPrisma.child.findFirst.mockResolvedValue(makeChildRecord());
+      admin.mockPrisma.childDocument.update.mockResolvedValue(
+        makeDocument({ deletedAt: new Date() }),
+      );
+      deleteFromStorageBestEffort.mockResolvedValue(false);
+
+      const result = await admin.caller.childDocuments.delete({ documentId: DOC_ID_1 });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should not touch the blob store when the document is not found', async () => {
+      admin.mockPrisma.childDocument.findFirst.mockResolvedValue(null);
+
+      await expect(
+        admin.caller.childDocuments.delete({ documentId: DOC_ID_1 }),
+      ).rejects.toThrow(TRPCError);
+
+      expect(deleteFromStorageBestEffort).not.toHaveBeenCalled();
     });
 
     it('should soft-delete a document for STAFF', async () => {

--- a/test/unit/credit-notes.spec.ts
+++ b/test/unit/credit-notes.spec.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+
+// TD-007 : le PDF d'avoir est câblé — on intercepte le rendu et l'upload pour
+// vérifier les données transmises au document sans lancer @react-pdf/renderer.
+const generateCreditNotePDF = vi.fn().mockResolvedValue(Buffer.from('%PDF-'));
+const uploadToStorage = vi.fn();
+
+vi.mock('@/lib/pdf/credit-note-pdf', () => ({
+  generateCreditNotePDF: (...args: unknown[]) => generateCreditNotePDF(...args),
+}));
+
+vi.mock('@/lib/storage/blob-storage', () => ({
+  uploadToStorage: (...args: unknown[]) => uploadToStorage(...args),
+  deleteFromStorage: vi.fn(),
+  deleteFromStorageBestEffort: vi.fn().mockResolvedValue(true),
+}));
+
 import {
   createTestCaller,
   ADMIN_USER,
@@ -71,6 +87,13 @@ describe('creditNotes router', () => {
     admin = createTestCaller(ADMIN_USER);
     staff = createTestCaller(STAFF_USER);
     parent = createTestCaller(PARENT_USER);
+    generateCreditNotePDF.mockClear();
+    generateCreditNotePDF.mockResolvedValue(Buffer.from('%PDF-'));
+    uploadToStorage.mockClear();
+    uploadToStorage.mockResolvedValue({
+      pathname: 'credit-notes/AVO-2025-0001.pdf',
+      url: 'https://store.blob.vercel-storage.com/credit-notes/AVO-2025-0001.pdf',
+    });
   });
 
   // --- Access control ---
@@ -281,5 +304,151 @@ describe('creditNotes router', () => {
 
     const result = await staff.caller.creditNotes.delete({ id: creditNoteId });
     expect(result.success).toBe(true);
+  });
+  // =========================================================================
+  // generatePDF (TD-007)
+  // =========================================================================
+
+  describe('generatePDF', () => {
+    const pdfCreditNote = {
+      ...fakeCreditNote,
+      creditedInvoice: { invoiceNumber: 'FAC-2025-0001' },
+      parent: {
+        firstName: 'Jean',
+        lastName: 'Dupont',
+        email: 'jean@test.com',
+        address: '15 Rue de la Baie',
+        city: 'Noumea',
+        postalCode: '98800',
+      },
+      lines: [
+        {
+          description: 'Remboursement partiel',
+          quantity: 1,
+          unitPrice: 10000,
+          totalPrice: 10000,
+          totalHt: -10000,
+        },
+      ],
+    };
+
+    it('should deny PARENT access', async () => {
+      await expect(
+        parent.caller.creditNotes.generatePDF({ id: creditNoteId }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('should throw NOT_FOUND when the credit note does not exist', async () => {
+      admin.mockPrisma.invoice.findFirst.mockResolvedValue(null);
+
+      await expect(
+        admin.caller.creditNotes.generatePDF({ id: creditNoteId }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      expect(uploadToStorage).not.toHaveBeenCalled();
+    });
+
+    it('should only look for credit notes (not invoices)', async () => {
+      admin.mockPrisma.invoice.findFirst.mockResolvedValue(null);
+
+      await expect(
+        admin.caller.creditNotes.generatePDF({ id: creditNoteId }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+      expect(admin.mockPrisma.invoice.findFirst.mock.calls[0]![0].where).toMatchObject({
+        id: creditNoteId,
+        invoiceType: 'CREDIT_NOTE',
+        deletedAt: null,
+      });
+    });
+
+    it('should generate, upload and persist the PDF URL', async () => {
+      admin.mockPrisma.invoice.findFirst.mockResolvedValue(pdfCreditNote);
+      admin.mockPrisma.invoice.update.mockResolvedValue({});
+
+      const result = await admin.caller.creditNotes.generatePDF({ id: creditNoteId });
+
+      expect(result).toEqual({
+        success: true,
+        pdfUrl: 'https://store.blob.vercel-storage.com/credit-notes/AVO-2025-0001.pdf',
+      });
+      expect(uploadToStorage).toHaveBeenCalledWith(expect.anything(), {
+        pathname: `credit-notes/AVO-2025-0001-${creditNoteId}.pdf`,
+        contentType: 'application/pdf',
+      });
+      expect(admin.mockPrisma.invoice.update).toHaveBeenCalledWith({
+        where: { id: creditNoteId },
+        data: {
+          pdfUrl: 'https://store.blob.vercel-storage.com/credit-notes/AVO-2025-0001.pdf',
+        },
+      });
+    });
+
+    it('should pass absolute amounts to the document (it prints the minus sign itself)', async () => {
+      admin.mockPrisma.invoice.findFirst.mockResolvedValue(pdfCreditNote);
+      admin.mockPrisma.invoice.update.mockResolvedValue({});
+
+      await admin.caller.creditNotes.generatePDF({ id: creditNoteId });
+
+      const data = generateCreditNotePDF.mock.calls[0]![0];
+      expect(data.totalAmount).toBe(11100);
+      expect(data.lines).toEqual([
+        {
+          description: 'Remboursement partiel',
+          quantity: 1,
+          unitPrice: 10000,
+          totalPrice: 10000,
+        },
+      ]);
+    });
+
+    it('should carry the credit note metadata (number, credited invoice, reason)', async () => {
+      admin.mockPrisma.invoice.findFirst.mockResolvedValue(pdfCreditNote);
+      admin.mockPrisma.invoice.update.mockResolvedValue({});
+
+      await admin.caller.creditNotes.generatePDF({ id: creditNoteId });
+
+      const data = generateCreditNotePDF.mock.calls[0]![0];
+      expect(data.creditNoteNumber).toBe('AVO-2025-0001');
+      expect(data.invoiceNumber).toBe('FAC-2025-0001');
+      expect(data.reason).toBe('Annulation partielle');
+      expect(data.parent.postalCode).toBe('98800');
+      expect(data.org.name).toBe('ALVM');
+    });
+
+    it('should label a standalone credit note as having no original invoice', async () => {
+      admin.mockPrisma.invoice.findFirst.mockResolvedValue({
+        ...pdfCreditNote,
+        creditedInvoiceId: null,
+        creditedInvoice: null,
+      });
+      admin.mockPrisma.invoice.update.mockResolvedValue({});
+
+      await admin.caller.creditNotes.generatePDF({ id: creditNoteId });
+
+      expect(generateCreditNotePDF.mock.calls[0]![0].invoiceNumber).toBe('Aucune');
+    });
+
+    it('should use the credit note footer mention from settings', async () => {
+      admin.mockPrisma.invoice.findFirst.mockResolvedValue(pdfCreditNote);
+      admin.mockPrisma.invoice.update.mockResolvedValue({});
+      admin.mockPrisma.appSetting.findMany.mockResolvedValue([
+        { category: 'documents', key: 'credit_note_footer', value: '"Avoir sans TGC"' },
+        { category: 'documents', key: 'invoice_footer', value: '"Mention facture"' },
+      ]);
+
+      await admin.caller.creditNotes.generatePDF({ id: creditNoteId });
+
+      expect(generateCreditNotePDF.mock.calls[0]![0].footerMention).toBe('Avoir sans TGC');
+    });
+
+    it('should allow STAFF to generate the PDF', async () => {
+      staff.mockPrisma.invoice.findFirst.mockResolvedValue(pdfCreditNote);
+      staff.mockPrisma.invoice.update.mockResolvedValue({});
+
+      const result = await staff.caller.creditNotes.generatePDF({ id: creditNoteId });
+
+      expect(result.success).toBe(true);
+    });
   });
 });

--- a/test/unit/email.service.spec.ts
+++ b/test/unit/email.service.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * TD-008 — service d'envoi d'emails transactionnels.
+ *
+ * Couvre le contrat vis-à-vis du fournisseur (payload, pièces jointes,
+ * erreurs) et la lecture de l'identité d'expédition dans les settings.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isEmailConfigured,
+  getEmailSender,
+  sendEmail,
+  escapeHtml,
+} from '@/server/services/email.service';
+
+const SENDER = {
+  fromName: 'ALVM',
+  fromEmail: 'noreply@alvm.nc',
+  replyTo: 'contact@alvm.nc',
+};
+
+function makePrisma(rows: Array<{ key: string; value: string | null }>) {
+  return {
+    appSetting: {
+      findMany: vi.fn().mockResolvedValue(rows),
+    },
+  };
+}
+
+describe('email.service (TD-008)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env.RESEND_API_KEY = 'resend_test_key';
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'email_123' }),
+      text: async () => '',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.RESEND_API_KEY;
+  });
+
+  describe('isEmailConfigured', () => {
+    it('reflects the presence of the provider key', () => {
+      expect(isEmailConfigured()).toBe(true);
+
+      delete process.env.RESEND_API_KEY;
+      expect(isEmailConfigured()).toBe(false);
+    });
+  });
+
+  describe('getEmailSender', () => {
+    it('reads the sender identity from the email settings', async () => {
+      const prisma = makePrisma([
+        { key: 'from_name', value: '"Association ALVM"' },
+        { key: 'from_email', value: '"facturation@alvm.nc"' },
+        { key: 'reply_to', value: '"contact@alvm.nc"' },
+      ]);
+
+      await expect(getEmailSender(prisma)).resolves.toEqual({
+        fromName: 'Association ALVM',
+        fromEmail: 'facturation@alvm.nc',
+        replyTo: 'contact@alvm.nc',
+      });
+      expect(prisma.appSetting.findMany).toHaveBeenCalledWith({
+        where: { category: 'email' },
+        select: { key: true, value: true },
+      });
+    });
+
+    it('falls back to the seeded defaults when settings are empty', async () => {
+      await expect(getEmailSender(makePrisma([]))).resolves.toEqual({
+        fromName: 'ALVM',
+        fromEmail: 'noreply@alvm.nc',
+        replyTo: undefined,
+      });
+    });
+
+    it('accepts legacy values stored without JSON quotes', async () => {
+      const sender = await getEmailSender(
+        makePrisma([{ key: 'from_email', value: 'facturation@alvm.nc' }]),
+      );
+
+      expect(sender.fromEmail).toBe('facturation@alvm.nc');
+    });
+  });
+
+  describe('sendEmail', () => {
+    it('posts a well-formed payload to the provider', async () => {
+      const result = await sendEmail(
+        { to: 'parent@example.nc', subject: 'Votre facture', html: '<p>Bonjour</p>' },
+        SENDER,
+      );
+
+      expect(result).toEqual({ id: 'email_123' });
+
+      const [url, init] = fetchMock.mock.calls[0]!;
+      expect(url).toBe('https://api.resend.com/emails');
+      expect(init.method).toBe('POST');
+      expect(init.headers.Authorization).toBe('Bearer resend_test_key');
+
+      const payload = JSON.parse(init.body);
+      expect(payload).toMatchObject({
+        from: 'ALVM <noreply@alvm.nc>',
+        to: ['parent@example.nc'],
+        reply_to: 'contact@alvm.nc',
+        subject: 'Votre facture',
+        html: '<p>Bonjour</p>',
+      });
+      expect(payload).not.toHaveProperty('attachments');
+    });
+
+    it('encodes attachments in base64', async () => {
+      await sendEmail(
+        {
+          to: 'parent@example.nc',
+          subject: 'Votre facture',
+          html: '<p>Bonjour</p>',
+          attachments: [
+            { filename: 'facture-FAC-2026-0001.pdf', content: Buffer.from('%PDF-1.7') },
+          ],
+        },
+        SENDER,
+      );
+
+      const payload = JSON.parse(fetchMock.mock.calls[0]![1].body);
+      expect(payload.attachments).toEqual([
+        {
+          filename: 'facture-FAC-2026-0001.pdf',
+          content: Buffer.from('%PDF-1.7').toString('base64'),
+        },
+      ]);
+    });
+
+    it('omits reply_to when no reply address is configured', async () => {
+      await sendEmail(
+        { to: 'parent@example.nc', subject: 'Sujet', html: '<p>Corps</p>' },
+        { fromName: 'ALVM', fromEmail: 'noreply@alvm.nc' },
+      );
+
+      expect(JSON.parse(fetchMock.mock.calls[0]![1].body)).not.toHaveProperty('reply_to');
+    });
+
+    it('fails explicitly when the provider key is missing', async () => {
+      delete process.env.RESEND_API_KEY;
+
+      await expect(
+        sendEmail({ to: 'parent@example.nc', subject: 'S', html: '<p>C</p>' }, SENDER),
+      ).rejects.toThrow('RESEND_API_KEY');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('reports the provider error status and body', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 422,
+        text: async () => 'domain is not verified',
+        json: async () => ({}),
+      });
+
+      await expect(
+        sendEmail({ to: 'parent@example.nc', subject: 'S', html: '<p>C</p>' }, SENDER),
+      ).rejects.toThrow(/422.*domain is not verified/s);
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('neutralises markup coming from stored data', () => {
+      expect(escapeHtml('Dupont & <b>Fils</b>')).toBe(
+        'Dupont &amp; &lt;b&gt;Fils&lt;/b&gt;',
+      );
+    });
+  });
+});

--- a/test/unit/invoices.spec.ts
+++ b/test/unit/invoices.spec.ts
@@ -1,5 +1,21 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+
+// Rendu PDF et upload Blob interceptés : les tests portent sur la chaîne
+// (requête, pièce jointe, persistance de l'URL), pas sur @react-pdf/renderer.
+const generateInvoicePDF = vi.fn();
+const uploadToStorage = vi.fn();
+
+vi.mock('@/lib/pdf/invoice-pdf', () => ({
+  generateInvoicePDF: (...args: unknown[]) => generateInvoicePDF(...args),
+}));
+
+vi.mock('@/lib/storage/blob-storage', () => ({
+  uploadToStorage: (...args: unknown[]) => uploadToStorage(...args),
+  deleteFromStorage: vi.fn(),
+  deleteFromStorageBestEffort: vi.fn().mockResolvedValue(true),
+}));
+
 import {
   createTestCaller,
   ADMIN_USER,
@@ -1703,7 +1719,74 @@ describe('invoices router', () => {
   // sendEmail
   // =========================================================================
 
-  describe('sendEmail', () => {
+  describe('sendEmail (TD-008)', () => {
+    const PDF_URL = 'https://store.blob.vercel-storage.com/invoices/FAC-2026-0001.pdf';
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    /** Facture complète telle que la lit `generateAndStoreInvoicePdf`. */
+    function makeInvoiceForPdf(overrides: Record<string, any> = {}) {
+      return {
+        // Facture émise par défaut : le cas brouillon (« devis ») a son test.
+        ...makeInvoiceRow({ status: 'SENT' }),
+        parent: {
+          firstName: 'Jean',
+          lastName: 'Dupont',
+          email: 'jean.dupont@example.nc',
+          address: '15 Rue de la Baie',
+          city: 'Noumea',
+          postalCode: '98800',
+        },
+        lines: [
+          {
+            description: 'Camp ete',
+            quantity: 1,
+            unitPrice: 10000,
+            totalPrice: 10000,
+          },
+        ],
+        payments: [],
+        ...overrides,
+      };
+    }
+
+    function arrangeHappyPath(invoice: Record<string, any> = makeInvoiceForPdf()) {
+      mockPrisma.invoice.findFirst.mockResolvedValue(invoice);
+      mockPrisma.invoice.update.mockResolvedValue({});
+      mockPrisma.appSetting.findUnique.mockResolvedValue(null);
+      mockPrisma.appSetting.findMany.mockResolvedValue([
+        { category: 'organization', key: 'short_name', value: '"ALVM"' },
+        { category: 'email', key: 'from_name', value: '"ALVM"' },
+        { category: 'email', key: 'from_email', value: '"noreply@alvm.nc"' },
+        { category: 'email', key: 'reply_to', value: '"contact@alvm.nc"' },
+      ]);
+      generateInvoicePDF.mockResolvedValue(Buffer.from('%PDF-facture'));
+      uploadToStorage.mockResolvedValue({ pathname: 'invoices/x.pdf', url: PDF_URL });
+    }
+
+    /** Corps JSON envoyé au fournisseur d'email. */
+    function sentPayload() {
+      return JSON.parse(fetchMock.mock.calls[0]![1].body);
+    }
+
+    beforeEach(() => {
+      ({ caller, mockPrisma } = createTestCaller(ADMIN_USER));
+      generateInvoicePDF.mockReset();
+      uploadToStorage.mockReset();
+      process.env.RESEND_API_KEY = 'resend_test_key';
+      fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'email_123' }),
+        text: async () => '',
+      });
+      vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      delete process.env.RESEND_API_KEY;
+    });
+
     it('rejects PARENT users', async () => {
       const { caller: parentCaller } = createTestCaller(PARENT_USER);
       await expect(
@@ -1711,12 +1794,111 @@ describe('invoices router', () => {
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     });
 
-    it('throws NOT_IMPLEMENTED for ADMIN users', async () => {
-      ({ caller, mockPrisma } = createTestCaller(ADMIN_USER));
+    it('fails with an explicit precondition error when email is not configured', async () => {
+      delete process.env.RESEND_API_KEY;
 
       await expect(
         caller.invoices.sendEmail({ id: INVOICE_ID }),
-      ).rejects.toThrow(TRPCError);
+      ).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+
+      // Aucun PDF généré, aucun appel réseau : on s'arrête avant.
+      expect(generateInvoicePDF).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws NOT_FOUND when the invoice does not exist', async () => {
+      mockPrisma.invoice.findFirst.mockResolvedValue(null);
+
+      await expect(
+        caller.invoices.sendEmail({ id: INVOICE_ID }),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('sends the invoice with its PDF attached', async () => {
+      arrangeHappyPath();
+
+      const result = await caller.invoices.sendEmail({ id: INVOICE_ID });
+
+      expect(result).toEqual({ success: true, sentTo: 'jean.dupont@example.nc' });
+      expect(fetchMock).toHaveBeenCalledOnce();
+
+      const payload = sentPayload();
+      expect(payload.to).toEqual(['jean.dupont@example.nc']);
+      expect(payload.from).toBe('ALVM <noreply@alvm.nc>');
+      expect(payload.reply_to).toBe('contact@alvm.nc');
+      expect(payload.subject).toContain('FAC-2026-0001');
+      expect(payload.attachments).toHaveLength(1);
+      expect(payload.attachments[0].filename).toBe('facture-FAC-2026-0001.pdf');
+      expect(Buffer.from(payload.attachments[0].content, 'base64').toString()).toBe(
+        '%PDF-facture',
+      );
+    });
+
+    it('archives the freshly generated PDF on the invoice', async () => {
+      arrangeHappyPath();
+
+      await caller.invoices.sendEmail({ id: INVOICE_ID });
+
+      expect(uploadToStorage).toHaveBeenCalledOnce();
+      expect(mockPrisma.invoice.update).toHaveBeenCalledWith({
+        where: { id: INVOICE_ID },
+        data: { pdfUrl: PDF_URL },
+      });
+    });
+
+    it('announces a quote (devis) while the invoice is still a draft', async () => {
+      arrangeHappyPath(makeInvoiceForPdf({ status: 'DRAFT' }));
+
+      await caller.invoices.sendEmail({ id: INVOICE_ID });
+
+      const payload = sentPayload();
+      expect(payload.subject).toContain('devis');
+      expect(payload.attachments[0].filename).toBe('devis-FAC-2026-0001.pdf');
+    });
+
+    it('refuses to send when the client has no email address', async () => {
+      arrangeHappyPath(
+        makeInvoiceForPdf({
+          parent: {
+            firstName: 'Jean',
+            lastName: 'Dupont',
+            email: null,
+            address: '15 Rue de la Baie',
+            city: 'Noumea',
+            postalCode: '98800',
+          },
+        }),
+      );
+
+      await expect(
+        caller.invoices.sendEmail({ id: INVOICE_ID }),
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a provider failure as a readable error', async () => {
+      arrangeHappyPath();
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 422,
+        text: async () => 'domain is not verified',
+        json: async () => ({}),
+      });
+
+      await expect(caller.invoices.sendEmail({ id: INVOICE_ID })).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: expect.stringContaining('422'),
+      });
+    });
+
+    it('allows STAFF to send', async () => {
+      ({ caller, mockPrisma } = createTestCaller(STAFF_USER));
+      arrangeHappyPath();
+
+      const result = await caller.invoices.sendEmail({ id: INVOICE_ID });
+
+      expect(result.success).toBe(true);
     });
   });
 

--- a/test/unit/settings.spec.ts
+++ b/test/unit/settings.spec.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+
+// TD-006 : le blob du logo doit suivre la ligne en base (suppression, remplacement).
+const deleteFromStorageBestEffort = vi.fn().mockResolvedValue(true);
+vi.mock('@/lib/storage/blob-storage', () => ({
+  uploadToStorage: vi.fn(),
+  deleteFromStorage: vi.fn(),
+  deleteFromStorageBestEffort: (...args: unknown[]) =>
+    deleteFromStorageBestEffort(...args),
+}));
+
 import {
   createTestCaller,
   ADMIN_USER,
@@ -26,6 +36,8 @@ describe('settings router', () => {
   beforeEach(() => {
     admin = createTestCaller(ADMIN_USER);
     staff = createTestCaller(STAFF_USER);
+    deleteFromStorageBestEffort.mockClear();
+    deleteFromStorageBestEffort.mockResolvedValue(true);
   });
 
   it('should deny unauthenticated access to getAll', async () => {
@@ -141,5 +153,106 @@ describe('settings router', () => {
     admin.mockPrisma.appSetting.deleteMany.mockResolvedValue({ count: 1 });
     const result = await admin.caller.settings.deleteLogoUrl();
     expect(result.success).toBe(true);
+  });
+
+  // TD-008 — l'UI doit savoir si l'envoi d'email est opérationnel
+  describe('isEmailConfigured (TD-008)', () => {
+    afterEach(() => {
+      delete process.env.RESEND_API_KEY;
+    });
+
+    it('should report not configured when the provider key is missing', async () => {
+      delete process.env.RESEND_API_KEY;
+
+      await expect(staff.caller.settings.isEmailConfigured()).resolves.toEqual({
+        configured: false,
+        fromEmail: null,
+      });
+      // Aucune lecture de settings inutile dans ce cas.
+      expect(staff.mockPrisma.appSetting.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should report the sender address when configured', async () => {
+      process.env.RESEND_API_KEY = 'resend_test_key';
+      staff.mockPrisma.appSetting.findMany.mockResolvedValue([
+        { key: 'from_email', value: '"facturation@alvm.nc"' },
+      ]);
+
+      await expect(staff.caller.settings.isEmailConfigured()).resolves.toEqual({
+        configured: true,
+        fromEmail: 'facturation@alvm.nc',
+      });
+    });
+
+    it('should deny PARENT access', async () => {
+      const { caller } = createTestCaller(PARENT_USER);
+      await expect(caller.settings.isEmailConfigured()).rejects.toThrow(TRPCError);
+    });
+  });
+
+  // TD-006 — blobs orphelins
+  describe('logo — nettoyage du blob (TD-006)', () => {
+    it('should delete the blob when the logo is removed', async () => {
+      admin.mockPrisma.appSetting.findUnique.mockResolvedValue({
+        value: '"https://store.blob.vercel-storage.com/logo.png"',
+      });
+      admin.mockPrisma.appSetting.deleteMany.mockResolvedValue({ count: 1 });
+
+      await admin.caller.settings.deleteLogoUrl();
+
+      expect(deleteFromStorageBestEffort).toHaveBeenCalledWith(
+        'https://store.blob.vercel-storage.com/logo.png',
+        expect.any(String),
+      );
+    });
+
+    it('should not call the store when no logo was set', async () => {
+      admin.mockPrisma.appSetting.findUnique.mockResolvedValue(null);
+      admin.mockPrisma.appSetting.deleteMany.mockResolvedValue({ count: 0 });
+
+      await admin.caller.settings.deleteLogoUrl();
+
+      expect(deleteFromStorageBestEffort).toHaveBeenCalledWith(undefined, expect.any(String));
+    });
+
+    it('should delete the previous blob when the logo is replaced', async () => {
+      admin.mockPrisma.appSetting.findUnique.mockResolvedValue({
+        value: '"https://store.blob.vercel-storage.com/old-logo.png"',
+      });
+      admin.mockPrisma.appSetting.upsert.mockResolvedValue({});
+
+      await admin.caller.settings.setLogoUrl({
+        url: 'https://store.blob.vercel-storage.com/new-logo.png',
+      });
+
+      expect(deleteFromStorageBestEffort).toHaveBeenCalledWith(
+        'https://store.blob.vercel-storage.com/old-logo.png',
+        expect.any(String),
+      );
+    });
+
+    it('should not delete the blob when the same URL is re-saved', async () => {
+      const url = 'https://store.blob.vercel-storage.com/logo.png';
+      admin.mockPrisma.appSetting.findUnique.mockResolvedValue({
+        value: JSON.stringify(url),
+      });
+      admin.mockPrisma.appSetting.upsert.mockResolvedValue({});
+
+      await admin.caller.settings.setLogoUrl({ url });
+
+      expect(deleteFromStorageBestEffort).not.toHaveBeenCalled();
+    });
+
+    it('should still succeed when the blob store fails', async () => {
+      admin.mockPrisma.appSetting.findUnique.mockResolvedValue({
+        value: '"https://store.blob.vercel-storage.com/logo.png"',
+      });
+      admin.mockPrisma.appSetting.deleteMany.mockResolvedValue({ count: 1 });
+      deleteFromStorageBestEffort.mockResolvedValue(false);
+
+      const result = await admin.caller.settings.deleteLogoUrl();
+
+      expect(result.success).toBe(true);
+    });
   });
 });

--- a/test/unit/staff-documents.spec.ts
+++ b/test/unit/staff-documents.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Router staffDocuments — suppression.
+ *
+ * Couvre notamment TD-006 : le blob doit être supprimé en même temps que la
+ * ligne, sans jamais faire échouer la suppression fonctionnelle.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import {
+  createTestCaller,
+  ADMIN_USER,
+  PARENT_USER,
+  type TestCaller,
+} from '../helpers/test-caller';
+
+const deleteFromStorageBestEffort = vi.fn().mockResolvedValue(true);
+vi.mock('@/lib/storage/blob-storage', () => ({
+  uploadToStorage: vi.fn(),
+  deleteFromStorage: vi.fn(),
+  deleteFromStorageBestEffort: (...args: unknown[]) =>
+    deleteFromStorageBestEffort(...args),
+}));
+
+const STAFF_ID = 'c0000000-0000-4000-a000-000000000001';
+const DOC_ID = 'c0000000-0000-4000-a000-000000000010';
+const FILE_URL = 'https://store.blob.vercel-storage.com/staff-documents/contrat.pdf';
+
+const now = new Date('2025-06-15T10:00:00Z');
+
+function makeDocument(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DOC_ID,
+    staffId: STAFF_ID,
+    filename: 'contrat-abc123.pdf',
+    originalFilename: 'contrat.pdf',
+    fileUrl: FILE_URL,
+    mimeType: 'application/pdf',
+    fileSize: 4096,
+    description: 'Contrat 2025',
+    uploadedBy: ADMIN_USER.id,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('staffDocuments router — delete', () => {
+  let admin: TestCaller;
+
+  beforeEach(() => {
+    admin = createTestCaller(ADMIN_USER);
+    deleteFromStorageBestEffort.mockClear();
+    deleteFromStorageBestEffort.mockResolvedValue(true);
+  });
+
+  it('should deny unauthenticated access', async () => {
+    const { caller } = createTestCaller(null);
+    await expect(
+      caller.staffDocuments.delete({ documentId: DOC_ID }),
+    ).rejects.toThrow(TRPCError);
+  });
+
+  it('should deny PARENT access', async () => {
+    const parent = createTestCaller(PARENT_USER);
+    parent.mockPrisma.staffDocument.findFirst.mockResolvedValue(makeDocument());
+
+    await expect(
+      parent.caller.staffDocuments.delete({ documentId: DOC_ID }),
+    ).rejects.toThrow('Accès réservé au personnel');
+  });
+
+  it('should soft-delete the row and delete the blob (TD-006)', async () => {
+    admin.mockPrisma.staffDocument.findFirst.mockResolvedValue(makeDocument());
+    admin.mockPrisma.staffMember.findFirst.mockResolvedValue({ userId: STAFF_ID });
+    admin.mockPrisma.staffDocument.update.mockResolvedValue(
+      makeDocument({ deletedAt: new Date() }),
+    );
+
+    const result = await admin.caller.staffDocuments.delete({ documentId: DOC_ID });
+
+    expect(result.success).toBe(true);
+    expect(admin.mockPrisma.staffDocument.update).toHaveBeenCalledWith({
+      where: { id: DOC_ID },
+      data: { deletedAt: expect.any(Date) },
+    });
+    expect(deleteFromStorageBestEffort).toHaveBeenCalledWith(FILE_URL, expect.any(String));
+  });
+
+  it('should still succeed when the blob store fails', async () => {
+    admin.mockPrisma.staffDocument.findFirst.mockResolvedValue(makeDocument());
+    admin.mockPrisma.staffMember.findFirst.mockResolvedValue({ userId: STAFF_ID });
+    admin.mockPrisma.staffDocument.update.mockResolvedValue(
+      makeDocument({ deletedAt: new Date() }),
+    );
+    deleteFromStorageBestEffort.mockResolvedValue(false);
+
+    const result = await admin.caller.staffDocuments.delete({ documentId: DOC_ID });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should not touch the blob store when the document is not found', async () => {
+    admin.mockPrisma.staffDocument.findFirst.mockResolvedValue(null);
+
+    await expect(
+      admin.caller.staffDocuments.delete({ documentId: DOC_ID }),
+    ).rejects.toThrow('Document non trouvé');
+
+    expect(deleteFromStorageBestEffort).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Trois dettes de la même famille : du code écrit, correct, mais qui n'était relié à rien — ou relié à un bouton qui échouait.

## TD-008 — `invoices.sendEmail` (P1)

La procédure levait inconditionnellement une `TRPCError` de code `'NOT_IMPLEMENTED' as any`. Ce code n'existe pas dans l'énumération tRPC : le `as any` était là pour faire taire le compilateur, pas par commodité. Et la procédure n'était pas morte — **deux boutons visibles** l'appelaient (« Envoyer par email » sur la fiche facture, « Envoyer le devis » dans la liste). L'application proposait donc une action qui échouait à tous les coups.

L'envoi est maintenant réel :

- `server/services/email.service.ts` — API REST Resend via `fetch`, aucun SDK ajouté au bundle serverless. La **clé** vient de l'environnement (`RESEND_API_KEY`, comme tout secret) ; l'**identité d'expédition** (nom, adresse, reply-to) des settings `email` déjà administrables dans /dashboard/admin/settings.
- `server/services/invoice-pdf.service.ts` — la génération du PDF de facture est extraite du router. `generatePDF` et `sendEmail` passent par la même fonction : la pièce jointe ne peut pas diverger du document téléchargeable.
- La facture part avec son PDF joint — ou le **devis**, tant qu'elle est en brouillon, ce que la liste proposait déjà.
- Erreurs typées, plus de code inventé : `PRECONDITION_FAILED` si l'environnement n'a pas de clé, `BAD_REQUEST` si le client n'a pas d'adresse, `INTERNAL_SERVER_ERROR` avec le statut et le motif renvoyés par le fournisseur.
- `settings.isEmailConfigured` expose l'état de configuration (booléen + adresse d'expédition, aucun secret) : le bouton de la fiche est désactivé et la boîte de dialogue de la liste explique l'indisponibilité, plutôt que de laisser l'utilisateur découvrir l'échec.

**Prérequis d'exploitation** : renseigner `RESEND_API_KEY` sur Vercel et vérifier le domaine d'envoi côté Resend. Sans cela l'app ne casse pas — elle dit que l'envoi est indisponible.

## TD-007 — PDF d'avoir

`CreditNotePDF` était complet, corrigé par TD-004 et couvert par `pdf-footer-overlap.spec.tsx`, mais sans procédure, ni route, ni bouton.

- `creditNotes.generatePDF` (staff) reprend la chaîne de `invoices.generatePDF` : settings PDF partagées, rendu, archivage Blob sous `credit-notes/{numéro}-{id}.pdf`, `pdfUrl` mémorisé sur la ligne et exposé par les mappers.
- **Signe des montants** : un avoir stocke ses montants négatifs alors que le document pose lui-même le « - » devant chaque valeur. La procédure transmet donc des valeurs absolues — sinon le PDF afficherait `--12 000 XPF`. Un test verrouille ce point.
- Un avoir autonome (sans facture d'origine) affiche « Aucune » plutôt qu'un champ vide.
- UI : bouton « Télécharger le PDF » sur la fiche de l'avoir et entrée dans le menu de la liste, avec le comportement de la facture (PDF déjà archivé ouvert directement, généré à la volée sinon).

## TD-006 — blobs orphelins

`deleteFromStorage` était exporté et appelé nulle part : supprimer un document enfant, un document personnel ou le logo retirait la ligne en base sans supprimer l'objet. Les fichiers restaient **accessibles par leur URL publique après leur suppression fonctionnelle** — un certificat médical « supprimé » restait lisible de quiconque avait gardé le lien — et facturés.

- `deleteFromStorageBestEffort(url, contexte)` : supprime l'objet, trace l'échec du store et le retient. **La base d'abord** (l'ordre inverse laisserait une ligne pointant vers le vide), **best effort** (un store injoignable ne doit pas ressusciter un document que l'utilisateur croit supprimé).
- Câblé dans `childDocuments.delete`, `staffDocuments.delete`, `settings.deleteLogoUrl` et `settings.setLogoUrl` (l'ancien logo remplacé, sauf ré-enregistrement de la même URL).
- `deleteFromStorage` échoue désormais explicitement sans `BLOB_READ_WRITE_TOKEN`, comme `uploadToStorage` le faisait déjà.
- **Reste à faire côté exploitation** : les blobs déjà orphelins d'avant ce correctif ne sont pas rattrapés par le code — inventaire et purge à faire une fois sur le store.

## Vérifications

- `pnpm test` — **1017 tests passent** (30 fichiers). Nouveaux : `blob-storage.spec.ts`, `email.service.spec.ts`, `staff-documents.spec.ts`. `sendEmail` est couvert de bout en bout (payload envoyé au fournisseur, pièce jointe base64, cas devis, absence de clé, absence d'adresse, refus du fournisseur), `creditNotes.generatePDF` également (montants absolus, chemin d'archivage, mention de pied de page).
- `pnpm typecheck` — OK.
- `pnpm lint` — 0 erreur, aucun nouvel avertissement (les 62 restants préexistent, cf. TD-001).
- `pnpm build` — OK.

Les tests unitaires sont mockés : ils ne voient ni les triggers legacy, ni le vrai store Blob, ni le fournisseur d'email. Une passe `pnpm smoke` / `pnpm recette` sur clone de prod reste à faire avant mise en prod, et l'envoi d'email demande un test réel une fois `RESEND_API_KEY` renseignée.

Docs à jour : `docs/dette-technique.md` (TD-006/007/008 en DONE), `CHANGELOG.md`, `CLAUDE.md` (trois nouvelles conventions), `docs/deploiement.md` et `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxFJwP1DfcPuboqYyBV1Ec

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxFJwP1DfcPuboqYyBV1Ec)_