### PR TITLE
TD-012 & TD-013: FEC SIREN naming + centralize status badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed — TD-012 : le SIREN de l'export FEC part enfin dans le fichier (2026-08-11)
+- **Un champ collecté puis jeté.** L'écran d'export affichait « SIREN
+  (optionnel) », le transmettait à `fec.generateFEC`, et la procédure ne le
+  lisait jamais. Le trésorier croyait le voir partir vers l'administration.
+- **Nommage réglementaire rétabli** : le fichier sort désormais en
+  `SIRENFECAAAAMMJJ.txt` (article A47 A-1 du LPF, AAAAMMJJ = date de fin de la
+  période exportée), au lieu de `FEC_AAAAMMJJ_AAAAMMJJ.txt`.
+- **Le SIREN se saisit une fois**, dans Paramètres → Comptabilité
+  (`accounting.fec_siren`, 9 chiffres) ; le champ de l'écran d'export ne fait
+  que le surcharger ponctuellement et s'y pré-remplit.
+- **Un SIREN saisi mais illisible est refusé** (`BAD_REQUEST`) plutôt que
+  silencieusement ignoré. Sans SIREN configuré, l'export **reste possible** sous
+  le nom historique, et l'écran affiche le nom produit avec un avertissement de
+  non-conformité : un export comptable ne se bloque pas pour un nommage.
+
+### Fixed — TD-013 : statuts affichés en enum brut et couleurs non calibrées (2026-08-11)
+- **`IMMEDIATE_REFUND` s'affichait tel quel** dans les deux tables de
+  remboursement, alors que `<StatusBadge />` portait « Remboursement immédiat »
+  sans jamais être appelé. `refund-details` en dupliquait un troisième mapping.
+- **Les badges d'ACM contournaient les couleurs calibrées WCAG AA** via trois
+  `getStatusBadge()` locaux identiques (couleurs Tailwind brutes, sans variante
+  sombre) — colonnes admin, colonnes staff et fiche détail.
+- Les six sites appellent maintenant `<StatusBadge />` ; les six helpers locaux
+  sont supprimés. C'était le doublon qui était mort, pas la table partagée.
+- **Libellés accentués** : `StatusBadge` affichait « Publie », « Payee »,
+  « Remboursement immediat ». Les libellés — seules chaînes du fichier destinées
+  à l'écran — sont accentués, ce qui corrige aussi les badges facture,
+  inscription et présence.
+
 ### Removed — deuxième passe de code mort (2026-08-10)
 - **Le routeur `auth` entier était mort.** Ses quatre procédures (`me`,
   `updateProfile`, `changePassword`, `deleteAccount`) n'étaient appelées par

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,24 @@ au lieu d'un appel HTTP au backend. Le mot de passe hashé est stocké dans
 - Les ecritures VE sont creees quand `status` passe a `SENT` (appel explicite dans le router)
 - Les ecritures BQ sont creees lors de la creation d'un paiement/remboursement
 
+### Nom du fichier FEC (TD-012)
+L'article A47 A-1 du LPF impose `SIRENFECAAAAMMJJ.txt` (AAAAMMJJ = date de
+cloture de l'exercice, ici la date de fin de la periode exportee). Le SIREN vit
+dans `app_settings.accounting.fec_siren` et se lit via `getFecSiren()` ; le
+champ de l'ecran d'export ne fait que le surcharger ponctuellement. Il ne figure
+PAS dans le contenu du fichier — les 18 colonnes du FEC n'ont pas ce champ.
+Sans SIREN, l'export reste possible sous le nom historique et l'ecran previent
+de la non-conformite : ne jamais bloquer un export comptable pour un nommage.
+
+### Afficher un statut : toujours `<StatusBadge />` (TD-013)
+`components/shared/status-badge.tsx` porte le libelle francais, la couleur
+calibree WCAG AA (utilities `status-badge-*` de `app/globals.css`) et l'icone
+de chaque statut metier. Ne jamais reecrire un `getStatusBadge()` local ni
+afficher l'enum brut : c'est exactement ce qui a fait lire `IMMEDIATE_REFUND`
+aux utilisateurs et contourner les couleurs calibrees sur les badges d'ACM.
+Un nouveau statut s'ajoute dans la table du fichier partage, avec son test dans
+`test/unit/status-badge.spec.ts`.
+
 ### Soft-delete
 - Extension Prisma `soft-delete.ts` ajoute `deletedAt: null` automatiquement
 - Pour les enregistrements supprimes : `{ deletedAt: { not: null } }`
@@ -196,7 +214,8 @@ Pour chaque router :
 ## Documents
 
 - `docs/deploiement.md` — topologie Vercel/Neon, vars d'env, procedure de migration, incident 2025-11.
-- `docs/dette-technique.md` — registre de dette (OPEN : TD-001 typage any des mappers ; TD-005 trigger legacy « dernier parent » absent du depot ; TD-009 aucune limitation de debit sur l'authentification ; TD-010 procedures tRPC sans ecran ; TD-011 auto-inscription parent sans serveur. DONE : TD-002 factures legacy 0 XPF ; TD-003 divergence des deux vues du solde d'un avoir ; TD-004 reserve du pied de page PDF ; TD-006 blobs orphelins ; TD-007 PDF d'avoir cable ; TD-008 envoi d'email implemente ; TD-A2 couverture PDF facture).
+- `docs/dette-technique.md` — registre de dette (OPEN : TD-001 typage any des mappers ; TD-005 trigger legacy « dernier parent » absent du depot ; TD-009 aucune limitation de debit sur l'authentification ; TD-010 procedures tRPC sans ecran ; TD-011 auto-inscription parent sans serveur. DONE : TD-002 factures legacy 0 XPF ; TD-003 divergence des deux vues du solde d'un avoir ; TD-004 reserve du pied de page PDF ; TD-006 blobs orphelins ; TD-007 PDF d'avoir cable ; TD-008 envoi d'email implemente ; TD-012 SIREN du FEC cable ; TD-013 statuts
+  affiches via StatusBadge ; TD-A2 couverture PDF facture).
 - `docs/stories/BACKLOG.md` — backlog produit + **backlog MIKADO livre le 2026-08-09** (7 US, arbitrages US-FACT-02 tranches) + **retours de recette livres le 2026-08-10** (4 US : PDF facture, selecteur d'avoir, suppression de parent).
 - `docs/test-evidence/recette-v2.0.1/` — recette visuelle Playwright (19/19 PASS, `pnpm recette`) + rapport de preuve.
 - `CHANGELOG.md` — journal des livraisons (v2.0.0 premiere prod de la refonte + v2.0.1 correctifs campagne smoke, 2026-07-06).

--- a/app/dashboard/admin/fec/export/page.tsx
+++ b/app/dashboard/admin/fec/export/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
@@ -24,10 +24,30 @@ import { trpc } from '@/lib/trpc/client';
 const fecExportSchema = z.object({
   startDate: z.string().min(1, 'Date de début requise'),
   endDate: z.string().min(1, 'Date de fin requise'),
-  siren: z.string().optional(),
+  siren: z
+    .string()
+    .optional()
+    .refine((v) => !v || /^\d{9}$/.test(v.replace(/\D/g, '')), {
+      message: 'SIREN invalide (9 chiffres)',
+    }),
 });
 
 type FECExportFormData = z.infer<typeof fecExportSchema>;
+
+/** Lit une valeur de setting (stockée JSON-stringifiée par `updateBulk`). */
+function readSetting(
+  settings: Array<{ key: string; value: unknown }> | undefined,
+  key: string,
+): string {
+  const raw = settings?.find((s) => s.key === key)?.value;
+  if (typeof raw !== 'string') return '';
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'string' ? parsed : '';
+  } catch {
+    return raw;
+  }
+}
 
 export default function FECExportPage() {
   const [error, setError] = useState<string | null>(null);
@@ -36,9 +56,19 @@ export default function FECExportPage() {
     totalDebit: number;
     totalCredit: number;
     balance: number;
+    filename: string;
+    siren: string | null;
   } | null>(null);
 
   const generateFECMutation = trpc.fec.generateFEC.useMutation();
+
+  // Le SIREN est un attribut de l'organisation, pas de l'export : on le
+  // pré-remplit depuis les paramètres comptables pour que le trésorier voie
+  // celui qui nommera réellement le fichier (TD-012).
+  const { data: accountingSettings } = trpc.settings.getByCategory.useQuery({
+    category: 'accounting',
+  });
+  const settingsSiren = readSetting(accountingSettings, 'fec_siren');
 
   const form = useForm<FECExportFormData>({
     resolver: zodResolver(fecExportSchema),
@@ -48,6 +78,13 @@ export default function FECExportPage() {
       siren: '',
     },
   });
+
+  const { setValue, getValues } = form;
+  useEffect(() => {
+    if (settingsSiren && !getValues('siren')) {
+      setValue('siren', settingsSiren);
+    }
+  }, [settingsSiren, setValue, getValues]);
 
   function downloadFEC(content: string, filename: string) {
     const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
@@ -77,6 +114,8 @@ export default function FECExportPage() {
         totalDebit: result.totalDebit,
         totalCredit: result.totalCredit,
         balance: result.balance,
+        filename: result.filename,
+        siren: result.siren,
       });
 
       // Télécharger le fichier FEC
@@ -118,6 +157,17 @@ export default function FECExportPage() {
             Total crédits : {exportStats.totalCredit.toLocaleString('fr-FR')} XPF
             <br />
             Balance : {(exportStats.totalDebit - exportStats.totalCredit).toLocaleString('fr-FR')} XPF
+            <br />
+            Fichier : <span className="font-mono">{exportStats.filename}</span>
+            {!exportStats.siren && (
+              <>
+                <br />
+                <span className="text-orange-700 dark:text-orange-400">
+                  Aucun SIREN renseigné : le fichier ne porte pas le nom attendu
+                  par l&apos;administration (SIRENFECAAAAMMJJ.txt).
+                </span>
+              </>
+            )}
           </AlertDescription>
         </Alert>
       )}
@@ -169,10 +219,13 @@ export default function FECExportPage() {
                   <FormItem>
                     <FormLabel>SIREN (optionnel)</FormLabel>
                     <FormControl>
-                      <Input placeholder="Ex: 123456789" {...field} />
+                      <Input placeholder="Ex: 123456789" className="font-mono" {...field} />
                     </FormControl>
                     <FormDescription>
-                      Numéro SIREN de l'organisation (9 chiffres)
+                      Nomme le fichier remis à l&apos;administration :{' '}
+                      <span className="font-mono">SIRENFECAAAAMMJJ.txt</span>{' '}
+                      (article A47 A-1 du LPF), où AAAAMMJJ est la date de fin
+                      ci-dessus. Pré-rempli depuis Paramètres → Comptabilité.
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/app/dashboard/admin/settings/page.tsx
+++ b/app/dashboard/admin/settings/page.tsx
@@ -73,6 +73,14 @@ const accountingSchema = z.object({
   fec_sales_account: z.string().regex(/^\d{6}$/, '6 chiffres requis'),
   fec_customers_account: z.string().regex(/^\d{6}$/, '6 chiffres requis'),
   fec_company_code: z.string().min(1, 'Code société requis'),
+  // Sert au nom du fichier FEC (SIRENFECAAAAMMJJ.txt, art. A47 A-1 du LPF).
+  // Optionnel : l'export reste possible sans, avec le nom historique.
+  fec_siren: z
+    .string()
+    .optional()
+    .refine((v) => !v || /^\d{9}$/.test(v.replace(/\D/g, '')), {
+      message: 'SIREN invalide (9 chiffres)',
+    }),
 });
 
 const documentsSchema = z.object({
@@ -248,6 +256,7 @@ export default function AdminSettingsPage() {
       fec_sales_account: '706000',
       fec_customers_account: '411000',
       fec_company_code: '',
+      fec_siren: '',
     },
     mode: 'onBlur',
   });
@@ -322,6 +331,7 @@ export default function AdminSettingsPage() {
         fec_sales_account: '706000',
         fec_customers_account: '411000',
         fec_company_code: '',
+        fec_siren: '',
         ...data,
       });
     }
@@ -993,6 +1003,31 @@ export default function AdminSettingsPage() {
                         />
                       </FormControl>
                       <FormDescription>Code identifiant votre société</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={accountingForm.control}
+                  name="fec_siren"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>SIREN</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          value={field.value || ''}
+                          placeholder="ex: 123456789"
+                          className="font-mono"
+                          disabled={updateMutation.isPending}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        9 chiffres. Nomme le fichier d&apos;export
+                        (SIRENFECAAAAMMJJ.txt, article A47 A-1 du LPF). Sans
+                        SIREN, l&apos;export garde son nom historique.
+                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}

--- a/components/admin/camps/columns.tsx
+++ b/components/admin/camps/columns.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { ColumnDef } from '@tanstack/react-table';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -22,6 +21,7 @@ import {
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { StatusBadge } from '@/components/shared/status-badge';
 
 // ============================================================================
 // TYPES
@@ -41,40 +41,6 @@ export type AdminCampType = {
   registrationsCount: number;
   availableSpots: number;
 };
-
-// ============================================================================
-// HELPERS
-// ============================================================================
-
-function getStatusBadge(status: string) {
-  switch (status) {
-    case 'DRAFT':
-      return {
-        label: 'Brouillon',
-        className: 'bg-gray-100 text-gray-800 border-gray-200',
-      };
-    case 'PUBLISHED':
-      return {
-        label: 'Publié',
-        className: 'bg-green-100 text-green-800 border-green-200',
-      };
-    case 'CLOSED':
-      return {
-        label: 'Fermé',
-        className: 'bg-red-100 text-red-800 border-red-200',
-      };
-    case 'CANCELLED':
-      return {
-        label: 'Annulé',
-        className: 'bg-orange-100 text-orange-800 border-orange-200',
-      };
-    default:
-      return {
-        label: status,
-        className: '',
-      };
-  }
-}
 
 // ============================================================================
 // COLUMN DEFINITIONS
@@ -149,14 +115,7 @@ export const adminCampColumns: ColumnDef<AdminCampType>[] = [
   {
     accessorKey: 'status',
     header: 'Statut',
-    cell: ({ row }) => {
-      const statusInfo = getStatusBadge(row.original.status);
-      return (
-        <Badge variant="outline" className={statusInfo.className}>
-          {statusInfo.label}
-        </Badge>
-      );
-    },
+    cell: ({ row }) => <StatusBadge type="camp" status={row.original.status} />,
   },
   {
     id: 'actions',

--- a/components/admin/refunds/columns.tsx
+++ b/components/admin/refunds/columns.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { MoreHorizontal, Eye, Trash2 } from 'lucide-react';
 import Link from 'next/link';
+import { StatusBadge } from '@/components/shared/status-badge';
 
 // ============================================================================
 // TYPES
@@ -83,13 +84,9 @@ export const adminRefundColumns: ColumnDef<AdminRefundType>[] = [
   {
     accessorKey: 'refundMethod',
     header: 'Méthode',
-    cell: ({ row }) => {
-      return (
-        <div className="text-sm">
-          {row.original.refundMethod}
-        </div>
-      );
-    },
+    cell: ({ row }) => (
+      <StatusBadge type="refund" status={row.original.refundMethod} />
+    ),
   },
   {
     accessorKey: 'amount',

--- a/components/admin/refunds/refund-details.tsx
+++ b/components/admin/refunds/refund-details.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { trpc } from '@/lib/trpc/client';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Loader2, FileText, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -21,6 +20,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import Link from 'next/link';
 import { useDashboardBasePath } from '@/lib/hooks/use-dashboard-base-path';
+import { StatusBadge } from '@/components/shared/status-badge';
 
 type Refund = {
   id: string;
@@ -50,11 +50,6 @@ type Refund = {
       };
     };
   };
-};
-
-const refundMethodLabels: Record<Refund['refundMethod'], string> = {
-  IMMEDIATE_REFUND: 'Remboursement immédiat',
-  FUTURE_CREDIT: 'Avoir / Crédit futur',
 };
 
 export function RefundDetails({ refund }: { refund: Refund }) {
@@ -100,7 +95,7 @@ export function RefundDetails({ refund }: { refund: Refund }) {
             </div>
             <div>
               <p className="text-sm text-muted-foreground">Méthode de remboursement</p>
-              <Badge variant="outline">{refundMethodLabels[refund.refundMethod]}</Badge>
+              <StatusBadge type="refund" status={refund.refundMethod} />
             </div>
             {refund.reference && (
               <div>

--- a/components/camps/camp-detail-page.tsx
+++ b/components/camps/camp-detail-page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ArrowLeft, Pencil, Users } from 'lucide-react';
 import Link from 'next/link';
+import { StatusBadge } from '@/components/shared/status-badge';
 import { CampDetailTab } from './camp-detail-tab';
 import { CampRegistrationsTab } from './camp-registrations-tab';
 import { CampAttendanceTab } from './camp-attendance-tab';
@@ -17,21 +18,6 @@ import { CampAttendanceTab } from './camp-attendance-tab';
 interface CampDetailPageProps {
   campId: string;
   basePath: string; // e.g. '/dashboard/admin/camps' or '/dashboard/staff/camps'
-}
-
-function getStatusBadge(status: string) {
-  switch (status) {
-    case 'DRAFT':
-      return { label: 'Brouillon', className: 'bg-gray-100 text-gray-800 border-gray-200' };
-    case 'PUBLISHED':
-      return { label: 'Publié', className: 'bg-green-100 text-green-800 border-green-200' };
-    case 'CLOSED':
-      return { label: 'Fermé', className: 'bg-red-100 text-red-800 border-red-200' };
-    case 'CANCELLED':
-      return { label: 'Annulé', className: 'bg-orange-100 text-orange-800 border-orange-200' };
-    default:
-      return { label: status, className: '' };
-  }
 }
 
 export function CampDetailPage({ campId, basePath }: CampDetailPageProps) {
@@ -71,8 +57,6 @@ export function CampDetailPage({ campId, basePath }: CampDetailPageProps) {
     );
   }
 
-  const statusInfo = getStatusBadge(camp.status);
-
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -81,9 +65,7 @@ export function CampDetailPage({ campId, basePath }: CampDetailPageProps) {
         description={camp.location}
         actions={
           <div className="flex items-center gap-2">
-            <Badge variant="outline" className={statusInfo.className}>
-              {statusInfo.label}
-            </Badge>
+            <StatusBadge type="camp" status={camp.status} />
             <Badge variant="outline" className="gap-1">
               <Users className="h-3 w-3" />
               {camp.registrationsCount} / {camp.maxCapacity}

--- a/components/shared/status-badge.tsx
+++ b/components/shared/status-badge.tsx
@@ -6,6 +6,11 @@
  *
  * Le mapping est exporte separement (`getStatusInfo`) pour pouvoir etre teste
  * en environnement Node (vitest) sans rendu React.
+ *
+ * Les `label` sont les seules chaines de ce fichier destinees a l'ecran : ils
+ * portent donc les accents. Les commentaires et identifiants restent en ASCII.
+ * Toute table de statut locale a un composant est un doublon a rebrancher ici
+ * (TD-013) — sinon l'ecran affiche l'enum brut ou des couleurs non calibrees.
  */
 
 import { Badge } from '@/components/ui/badge';
@@ -65,25 +70,25 @@ const UNKNOWN_INFO: StatusInfo = {
 
 const INVOICE_MAP: Record<string, StatusInfo> = {
   DRAFT: { label: 'Devis', className: 'status-badge-draft', icon: FileText },
-  SENT: { label: 'Emise', className: 'status-badge-sent', icon: Send },
-  PAID: { label: 'Payee', className: 'status-badge-paid', icon: CheckCircle2 },
+  SENT: { label: 'Émise', className: 'status-badge-sent', icon: Send },
+  PAID: { label: 'Payée', className: 'status-badge-paid', icon: CheckCircle2 },
   OVERDUE: { label: 'En retard', className: 'status-badge-overdue', icon: AlertCircle },
-  CANCELLED: { label: 'Annulee', className: 'status-badge-cancelled', icon: XCircle },
-  CREDITED: { label: 'Creditee', className: 'status-badge-credited', icon: RefreshCcw },
+  CANCELLED: { label: 'Annulée', className: 'status-badge-cancelled', icon: XCircle },
+  CREDITED: { label: 'Créditée', className: 'status-badge-credited', icon: RefreshCcw },
 };
 
 const REGISTRATION_MAP: Record<string, StatusInfo> = {
   PENDING: { label: 'En attente', className: 'status-badge-pending', icon: Clock },
-  CONFIRMED: { label: 'Confirmee', className: 'status-badge-confirmed', icon: CheckCircle },
-  CANCELLED: { label: 'Annulee', className: 'status-badge-cancelled', icon: XCircle },
+  CONFIRMED: { label: 'Confirmée', className: 'status-badge-confirmed', icon: CheckCircle },
+  CANCELLED: { label: 'Annulée', className: 'status-badge-cancelled', icon: XCircle },
   WAITLIST: { label: "Liste d'attente", className: 'status-badge-waitlist', icon: AlertTriangle },
 };
 
 const ATTENDANCE_MAP: Record<string, StatusInfo> = {
-  PRESENT: { label: 'Present', className: 'status-badge-present', icon: CheckCircle },
+  PRESENT: { label: 'Présent', className: 'status-badge-present', icon: CheckCircle },
   ABSENT: { label: 'Absent', className: 'status-badge-absent', icon: XCircle },
   LATE: { label: 'En retard', className: 'status-badge-late', icon: Clock },
-  EXCUSED: { label: 'Excuse', className: 'status-badge-excused', icon: PauseCircle },
+  EXCUSED: { label: 'Excusé', className: 'status-badge-excused', icon: PauseCircle },
 };
 
 const CREDIT_NOTE_MAP: Record<string, StatusInfo> = {
@@ -91,31 +96,31 @@ const CREDIT_NOTE_MAP: Record<string, StatusInfo> = {
   // seuls DRAFT / SENT / CANCELLED sont utilises. ISSUED et APPLIED restent supportes
   // au cas ou un schema enrichi serait introduit.
   DRAFT: { label: 'Brouillon', className: 'status-badge-draft', icon: FileText },
-  SENT: { label: 'Emis', className: 'status-badge-sent', icon: Send },
-  ISSUED: { label: 'Emis', className: 'status-badge-issued', icon: Send },
-  APPLIED: { label: 'Applique', className: 'status-badge-applied', icon: CheckCircle2 },
-  CANCELLED: { label: 'Annule', className: 'status-badge-cancelled', icon: XCircle },
+  SENT: { label: 'Émis', className: 'status-badge-sent', icon: Send },
+  ISSUED: { label: 'Émis', className: 'status-badge-issued', icon: Send },
+  APPLIED: { label: 'Appliqué', className: 'status-badge-applied', icon: CheckCircle2 },
+  CANCELLED: { label: 'Annulé', className: 'status-badge-cancelled', icon: XCircle },
 };
 
 const CAMP_MAP: Record<string, StatusInfo> = {
   DRAFT: { label: 'Brouillon', className: 'status-badge-draft', icon: FileText },
-  PUBLISHED: { label: 'Publie', className: 'status-badge-published', icon: CheckCircle },
-  CLOSED: { label: 'Ferme', className: 'status-badge-closed', icon: PauseCircle },
-  CANCELLED: { label: 'Annule', className: 'status-badge-cancelled', icon: XCircle },
+  PUBLISHED: { label: 'Publié', className: 'status-badge-published', icon: CheckCircle },
+  CLOSED: { label: 'Fermé', className: 'status-badge-closed', icon: PauseCircle },
+  CANCELLED: { label: 'Annulé', className: 'status-badge-cancelled', icon: XCircle },
 };
 
 const PAYMENT_MAP: Record<string, StatusInfo> = {
   // PaymentStatus enum dans le schema Prisma s'applique aux factures, mais cette
   // table peut aussi servir a etiqueter un Payment isole si besoin.
-  UNPAID: { label: 'Non paye', className: 'status-badge-unpaid', icon: Clock },
+  UNPAID: { label: 'Non payé', className: 'status-badge-unpaid', icon: Clock },
   PARTIAL: { label: 'Partiel', className: 'status-badge-partial', icon: Wallet },
-  PAID: { label: 'Paye', className: 'status-badge-paid', icon: CheckCircle2 },
-  REFUNDED: { label: 'Rembourse', className: 'status-badge-refunded', icon: RefreshCcw },
+  PAID: { label: 'Payé', className: 'status-badge-paid', icon: CheckCircle2 },
+  REFUNDED: { label: 'Remboursé', className: 'status-badge-refunded', icon: RefreshCcw },
 };
 
 const REFUND_MAP: Record<string, StatusInfo> = {
   IMMEDIATE_REFUND: {
-    label: 'Remboursement immediat',
+    label: 'Remboursement immédiat',
     className: 'status-badge-immediate-refund',
     icon: CreditCard,
   },

--- a/components/staff/camps/columns.tsx
+++ b/components/staff/camps/columns.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { ColumnDef } from '@tanstack/react-table';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -23,6 +22,7 @@ import {
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { StatusBadge } from '@/components/shared/status-badge';
 
 // ============================================================================
 // TYPES
@@ -42,40 +42,6 @@ export type StaffCampType = {
   registrationsCount: number;
   availableSpots: number;
 };
-
-// ============================================================================
-// HELPERS
-// ============================================================================
-
-function getStatusBadge(status: string) {
-  switch (status) {
-    case 'DRAFT':
-      return {
-        label: 'Brouillon',
-        className: 'bg-gray-100 text-gray-800 border-gray-200',
-      };
-    case 'PUBLISHED':
-      return {
-        label: 'Publié',
-        className: 'bg-green-100 text-green-800 border-green-200',
-      };
-    case 'CLOSED':
-      return {
-        label: 'Fermé',
-        className: 'bg-red-100 text-red-800 border-red-200',
-      };
-    case 'CANCELLED':
-      return {
-        label: 'Annulé',
-        className: 'bg-orange-100 text-orange-800 border-orange-200',
-      };
-    default:
-      return {
-        label: status,
-        className: '',
-      };
-  }
-}
 
 // ============================================================================
 // COLUMN DEFINITIONS
@@ -150,14 +116,7 @@ export const staffCampColumns: ColumnDef<StaffCampType>[] = [
   {
     accessorKey: 'status',
     header: 'Statut',
-    cell: ({ row }) => {
-      const statusInfo = getStatusBadge(row.original.status);
-      return (
-        <Badge variant="outline" className={statusInfo.className}>
-          {statusInfo.label}
-        </Badge>
-      );
-    },
+    cell: ({ row }) => <StatusBadge type="camp" status={row.original.status} />,
   },
   {
     id: 'actions',

--- a/components/staff/refunds/columns.tsx
+++ b/components/staff/refunds/columns.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { MoreHorizontal, Eye, Pencil } from 'lucide-react';
 import Link from 'next/link';
+import { StatusBadge } from '@/components/shared/status-badge';
 
 // ============================================================================
 // TYPES
@@ -87,13 +88,9 @@ export const staffRefundColumns: ColumnDef<StaffRefundType>[] = [
   {
     accessorKey: 'refundMethod',
     header: 'Méthode',
-    cell: ({ row }) => {
-      return (
-        <div className="text-sm">
-          {row.original.refundMethod}
-        </div>
-      );
-    },
+    cell: ({ row }) => (
+      <StatusBadge type="refund" status={row.original.refundMethod} />
+    ),
   },
   {
     accessorKey: 'reference',

--- a/docs/dette-technique.md
+++ b/docs/dette-technique.md
@@ -207,6 +207,64 @@ une action qui échouait à tous les coups.
 vérifier le domaine d'envoi côté Resend (voir `docs/deploiement.md`). Sans
 cela, l'application ne casse pas — elle dit que l'envoi est indisponible.
 
+## TD-012 — Le SIREN de l'export FEC était collecté puis jeté — P2 — DONE (2026-08-11)
+
+**Constat (2026-08-11)** : l'écran d'export FEC affichait un champ « SIREN
+(optionnel) », le formulaire le transmettait à `fec.generateFEC`, la procédure
+l'acceptait dans son schéma Zod… et ne le lisait jamais. Un trésorier qui le
+renseignait croyait qu'il partait dans le fichier remis à l'administration.
+Conséquence : le fichier sortait sous le nom `FEC_AAAAMMJJ_AAAAMMJJ.txt`, là où
+l'article A47 A-1 du LPF attend `SIRENFECAAAAMMJJ.txt` (AAAAMMJJ = date de
+clôture de l'exercice).
+
+**Arbitrage** : câbler plutôt que supprimer — le nommage est une exigence
+réglementaire, pas un confort. Retirer le champ aurait supprimé le symptôme en
+laissant l'export non conforme.
+
+**Résolution livrée** :
+- `accounting.fec_siren` ajouté aux paramètres (onglet Comptabilité, validé à
+  9 chiffres, seedé vide). Le SIREN est un attribut de l'organisation : le
+  trésorier ne le ressaisit plus à chaque export.
+- `getFecSiren()` / `normalizeSiren()` dans `server/helpers/settings.ts`.
+  `normalizeSiren` tolère les séparateurs de lisibilité et la valeur
+  JSON-stringifiée écrite par `settings.updateBulk`.
+- `fec.generateFEC` : SIREN saisi > SIREN des settings ; nomme le fichier
+  `SIRENFECAAAAMMJJ.txt` à partir de la date de fin ; **rejette** (BAD_REQUEST)
+  un SIREN saisi mais illisible plutôt que de produire un fichier mal nommé ;
+  renvoie `siren` pour que l'écran dise ce qui a réellement servi.
+- Sans SIREN nulle part, l'export **reste possible** sous le nom historique et
+  l'écran affiche le nom produit + un avertissement de non-conformité. Un
+  export bloqué serait pire qu'un export mal nommé.
+
+**Ce que le SIREN ne fait pas** : il n'entre pas dans le contenu du fichier —
+les 18 colonnes du FEC ne comportent pas ce champ. Ne pas l'ajouter à
+`generateFECContent`.
+
+## TD-013 — Statuts affichés en enum brut et couleurs non calibrées — P3 — DONE (2026-08-11)
+
+**Constat (2026-08-11)** : `<StatusBadge />` centralise label français, couleur
+calibrée WCAG AA (utilities `status-badge-*`) et icône pour chaque statut métier
+— mais trois de ses tables n'avaient aucun appelant, alors que l'affichage
+correspondant existait ailleurs, fait à la main et moins bien :
+- les deux tables de remboursement (admin + staff) affichaient `IMMEDIATE_REFUND`
+  tel quel à l'utilisateur, alors que `REFUND_MAP` portait le libellé français ;
+- `refund-details.tsx` dupliquait ce mapping en local (`refundMethodLabels`) ;
+- les trois affichages de statut d'ACM (colonnes admin, colonnes staff, fiche
+  détail) recopiaient chacun un `getStatusBadge()` local avec des couleurs
+  Tailwind brutes (`bg-green-100`…), contournant les couleurs calibrées et le
+  mode sombre.
+
+**Résolution livrée** : les six sites appellent `<StatusBadge />`. Les six
+helpers/tables locaux sont supprimés — c'était le doublon qui était mort, pas la
+table partagée.
+
+**Effet de bord assumé** : les libellés de `StatusBadge` portaient des lettres
+non accentuées (« Publie », « Payee », « Remboursement immediat »). Rebrancher
+les badges d'ACM dessus aurait dégradé un affichage jusque-là accentué : les
+libellés — seules chaînes de ce fichier destinées à l'écran — ont donc été
+accentués, ce qui corrige du même coup les badges facture, inscription et
+présence. Commentaires et identifiants restent en ASCII.
+
 ## TD-005 — Trigger legacy « dernier parent » absent du dépôt — P2 — OPEN
 
 **Constat (2026-08-10, US-FAM-01/02)** : l'invariant « un enfant a toujours au

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -225,6 +225,7 @@ async function main() {
     { category: 'accounting', key: 'fec_sales_account', value: '"706000"', description: "Compte de ventes par défaut (FEC)" },
     { category: 'accounting', key: 'fec_customers_account', value: '"411000"', description: "Compte clients (FEC)" },
     { category: 'accounting', key: 'fec_company_code', value: '"ALVM"', description: "Code société (FEC)" },
+    { category: 'accounting', key: 'fec_siren', value: '""', description: "SIREN utilisé pour nommer le fichier FEC (SIRENFECAAAAMMJJ.txt, art. A47 A-1 du LPF)" },
   ];
 
   for (const s of settings) {

--- a/server/helpers/settings.ts
+++ b/server/helpers/settings.ts
@@ -92,6 +92,49 @@ export async function getCreditExpiryDate(
 }
 
 /**
+ * Normalise un SIREN saisi ou stocké : accepte les séparateurs de lisibilité
+ * (« 123 456 789 », « 123.456.789 ») et la valeur JSON-stringifiée produite par
+ * `settings.updateBulk`.
+ *
+ * @returns les 9 chiffres, ou `null` si la valeur ne forme pas un SIREN.
+ */
+export function normalizeSiren(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+
+  let value = raw;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === 'string') value = parsed;
+    else if (typeof parsed === 'number') value = String(parsed);
+  } catch {
+    // Valeur stockée en clair (legacy) — on garde la chaîne brute.
+  }
+
+  const digits = value.replace(/\D/g, '');
+  return digits.length === 9 ? digits : null;
+}
+
+/**
+ * SIREN de l'organisation, utilisé pour nommer le fichier FEC.
+ *
+ * L'article A47 A-1 du LPF impose le nom `SIRENFECAAAAMMJJ.txt` (AAAAMMJJ =
+ * date de clôture de l'exercice). Le SIREN n'est PAS une colonne du fichier :
+ * il ne sert qu'au nommage, d'où sa lecture ici et nulle part dans
+ * `generateFECContent`.
+ *
+ * Retourne `null` si la clé est absente ou malformée : l'export reste possible,
+ * seul le nommage réglementaire est perdu (le router le signale à l'appelant).
+ */
+export async function getFecSiren(prisma: HasAppSetting): Promise<string | null> {
+  const row = await prisma.appSetting.findUnique({
+    where: { category_key: { category: 'accounting', key: 'fec_siren' } },
+    select: { value: true },
+  });
+
+  return normalizeSiren(row?.value);
+}
+
+/**
  * Parses a setting value into a number. Tolerates:
  *  - JSON-encoded numbers (e.g. "30", "0.11")
  *  - Plain numeric strings ("30")

--- a/server/routers/fec.ts
+++ b/server/routers/fec.ts
@@ -3,6 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { router, adminProcedure } from '@/server/trpc/init';
 import type { Prisma } from '@prisma/client';
 import { toNum } from '@/server/helpers/decimal';
+import { getFecSiren, normalizeSiren } from '@/server/helpers/settings';
 
 // ============================================================================
 // SCHEMAS
@@ -90,6 +91,26 @@ function generateFECContent(entries: any[]): string {
   return content;
 }
 
+/**
+ * Nom du fichier FEC.
+ *
+ * Article A47 A-1 du LPF : `SIRENFECAAAAMMJJ.txt`, où AAAAMMJJ est la date de
+ * clôture de l'exercice — ici la date de fin de la période exportée.
+ *
+ * Sans SIREN, on retombe sur le nom historique `FEC_debut_fin.txt` : le fichier
+ * reste exploitable par un logiciel comptable, mais il n'est pas conforme au
+ * nommage attendu par l'administration. Le router le signale via `siren: null`.
+ */
+function buildFECFilename(
+  siren: string | null,
+  startDate: string,
+  endDate: string,
+): string {
+  const fileEndDate = endDate.replace(/-/g, '');
+  if (siren) return `${siren}FEC${fileEndDate}.txt`;
+  return `FEC_${startDate.replace(/-/g, '')}_${fileEndDate}.txt`;
+}
+
 function mapEntry(e: any) {
   return {
     id: e.id,
@@ -154,17 +175,34 @@ export const fecRouter = router({
     .input(z.object({
       startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Format date invalide (YYYY-MM-DD)'),
       endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Format date invalide (YYYY-MM-DD)'),
+      // SIREN de l'exportateur : sert UNIQUEMENT au nom du fichier (A47 A-1).
+      // Vide ou absent → on prend celui des settings (accounting.fec_siren).
       siren: z.string().optional(),
     }))
     .output(z.object({
       content: z.string(),
       filename: z.string(),
+      /** SIREN effectivement utilisé pour nommer le fichier, `null` si aucun. */
+      siren: z.string().nullable(),
       entryCount: z.number(),
       totalDebit: z.number(),
       totalCredit: z.number(),
       balance: z.number(),
     }))
     .mutation(async ({ ctx, input }) => {
+      // Un SIREN saisi mais illisible est une erreur de l'utilisateur : le
+      // laisser passer silencieusement produirait un fichier mal nommé, ce que
+      // le trésorier ne verrait qu'au dépôt.
+      const typedSiren = input.siren?.trim() ? normalizeSiren(input.siren) : null;
+      if (input.siren?.trim() && !typedSiren) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'SIREN invalide : 9 chiffres attendus',
+        });
+      }
+
+      const siren = typedSiren ?? (await getFecSiren(ctx.prisma));
+
       const entries = await ctx.prisma.accountingEntry.findMany({
         where: {
           entryDate: {
@@ -207,13 +245,12 @@ export const fecRouter = router({
 
       const content = generateFECContent(mapped);
 
-      const fileStartDate = input.startDate.replace(/-/g, '');
-      const fileEndDate = input.endDate.replace(/-/g, '');
-      const filename = `FEC_${fileStartDate}_${fileEndDate}.txt`;
+      const filename = buildFECFilename(siren, input.startDate, input.endDate);
 
       return {
         content,
         filename,
+        siren,
         entryCount: entries.length,
         totalDebit,
         totalCredit,

--- a/test/e2e-smoke/smoke.mjs
+++ b/test/e2e-smoke/smoke.mjs
@@ -221,6 +221,13 @@ async function main() {
   const fec = await m('fec.generateFEC', { startDate: '2026-01-01', endDate: '2026-12-31' }, admin.jar);
   const fecLines = (fec.data?.content ?? '').trim().split('\n');
   check('fec', 'export FEC généré avec écritures', fecLines.length > 2, `${fecLines.length} lignes`);
+  // TD-012 : le SIREN nomme le fichier (art. A47 A-1 du LPF), il n'est pas une colonne.
+  const fecNamed = await m('fec.generateFEC', { startDate: '2026-01-01', endDate: '2026-12-31', siren: '123 456 789' }, admin.jar);
+  check('fec', 'nom du fichier SIRENFECAAAAMMJJ.txt',
+    fecNamed.data?.filename === '123456789FEC20261231.txt', `${fecNamed.data?.filename}`);
+  const fecBadSiren = await m('fec.generateFEC', { startDate: '2026-01-01', endDate: '2026-12-31', siren: '1234' }, admin.jar);
+  check('fec', 'SIREN illisible refusé (pas de fichier mal nommé)',
+    fecBadSiren.error?.data?.code === 'BAD_REQUEST', JSON.stringify(fecBadSiren.error ?? '').slice(0, 160));
 
   // ————— M. PDF —————
   const pdfOk = await fetch(`${BASE}/api/generate/child-profile/${childId}`, { headers: { Cookie: cookieHeader(admin.jar) } });

--- a/test/unit/fec.spec.ts
+++ b/test/unit/fec.spec.ts
@@ -124,8 +124,87 @@ describe('fec router', () => {
     expect(result.totalCredit).toBe(10000);
     expect(result.balance).toBe(0);
     expect(result.filename).toBe('FEC_20250101_20251231.txt');
+    expect(result.siren).toBeNull();
     expect(result.content).toContain('JournalCode|JournalLib|');
     expect(result.content).toContain('VE|Journal des Ventes|');
+  });
+
+  // --- generateFEC : nommage reglementaire (TD-012) ---
+
+  describe('nom du fichier (article A47 A-1 du LPF)', () => {
+    beforeEach(() => {
+      admin.mockPrisma.accountingEntry.findMany.mockResolvedValue([fakeEntry, fakeCounterEntry]);
+    });
+
+    it('names the file SIRENFECAAAAMMJJ.txt from the SIREN typed by the user', async () => {
+      const result = await admin.caller.fec.generateFEC({
+        startDate: '2025-01-01',
+        endDate: '2025-12-31',
+        siren: '123456789',
+      });
+
+      expect(result.filename).toBe('123456789FEC20251231.txt');
+      expect(result.siren).toBe('123456789');
+    });
+
+    it('accepts a SIREN typed with separators', async () => {
+      const result = await admin.caller.fec.generateFEC({
+        startDate: '2025-01-01',
+        endDate: '2025-12-31',
+        siren: '123 456 789',
+      });
+
+      expect(result.filename).toBe('123456789FEC20251231.txt');
+    });
+
+    it('falls back to accounting.fec_siren when the field is left empty', async () => {
+      admin.mockPrisma.appSetting.findUnique.mockResolvedValue({ value: '"987654321"' });
+
+      const result = await admin.caller.fec.generateFEC({
+        startDate: '2025-01-01',
+        endDate: '2025-12-31',
+      });
+
+      expect(admin.mockPrisma.appSetting.findUnique).toHaveBeenCalledWith({
+        where: { category_key: { category: 'accounting', key: 'fec_siren' } },
+        select: { value: true },
+      });
+      expect(result.filename).toBe('987654321FEC20251231.txt');
+      expect(result.siren).toBe('987654321');
+    });
+
+    it('prefers the typed SIREN over the stored one', async () => {
+      admin.mockPrisma.appSetting.findUnique.mockResolvedValue({ value: '"987654321"' });
+
+      const result = await admin.caller.fec.generateFEC({
+        startDate: '2025-01-01',
+        endDate: '2025-12-31',
+        siren: '123456789',
+      });
+
+      expect(result.filename).toBe('123456789FEC20251231.txt');
+    });
+
+    it('rejects a malformed SIREN instead of silently misnaming the file', async () => {
+      await expect(
+        admin.caller.fec.generateFEC({
+          startDate: '2025-01-01',
+          endDate: '2025-12-31',
+          siren: '1234',
+        }),
+      ).rejects.toThrow('SIREN invalide');
+    });
+
+    it('keeps the legacy name when no SIREN is configured anywhere', async () => {
+      const result = await admin.caller.fec.generateFEC({
+        startDate: '2025-01-01',
+        endDate: '2025-12-31',
+        siren: '   ',
+      });
+
+      expect(result.filename).toBe('FEC_20250101_20251231.txt');
+      expect(result.siren).toBeNull();
+    });
   });
 
   it('should throw if no entries found', async () => {

--- a/test/unit/settings.helper.spec.ts
+++ b/test/unit/settings.helper.spec.ts
@@ -10,6 +10,8 @@ import {
   getTaxRateDecimal,
   getDefaultDueDate,
   getCreditExpiryDate,
+  getFecSiren,
+  normalizeSiren,
 } from '@/server/helpers/settings';
 
 function makeFakePrisma(value: string | null | undefined) {
@@ -142,6 +144,53 @@ describe('settings.helper — pricing values', () => {
       const result = await getCreditExpiryDate(prisma as any);
       expect(result).toBeInstanceOf(Date);
       expect(Number.isNaN(result.getTime())).toBe(false);
+    });
+  });
+});
+
+describe('settings.helper — SIREN du FEC (TD-012)', () => {
+  describe('normalizeSiren', () => {
+    it('accepts 9 raw digits', () => {
+      expect(normalizeSiren('123456789')).toBe('123456789');
+    });
+
+    it('unwraps the JSON-stringified value written by settings.updateBulk', () => {
+      expect(normalizeSiren('"123456789"')).toBe('123456789');
+    });
+
+    it('strips readability separators', () => {
+      expect(normalizeSiren('123 456 789')).toBe('123456789');
+      expect(normalizeSiren('"123.456.789"')).toBe('123456789');
+    });
+
+    it('preserves a leading zero (quoted value stays a string)', () => {
+      expect(normalizeSiren('"012345678"')).toBe('012345678');
+    });
+
+    it('rejects anything that is not exactly 9 digits', () => {
+      expect(normalizeSiren('12345678')).toBeNull();
+      expect(normalizeSiren('1234567890')).toBeNull();
+      expect(normalizeSiren('"ALVM"')).toBeNull();
+      expect(normalizeSiren('""')).toBeNull();
+      expect(normalizeSiren('')).toBeNull();
+      expect(normalizeSiren(null)).toBeNull();
+      expect(normalizeSiren(undefined)).toBeNull();
+    });
+  });
+
+  describe('getFecSiren', () => {
+    it('reads accounting.fec_siren', async () => {
+      const prisma = makeFakePrisma('"123456789"');
+      await expect(getFecSiren(prisma as any)).resolves.toBe('123456789');
+      expect(prisma.appSetting.findUnique).toHaveBeenCalledWith({
+        where: { category_key: { category: 'accounting', key: 'fec_siren' } },
+        select: { value: true },
+      });
+    });
+
+    it('returns null when the key was never filled in', async () => {
+      await expect(getFecSiren(makeFakePrisma(undefined) as any)).resolves.toBeNull();
+      await expect(getFecSiren(makeFakePrisma('""') as any)).resolves.toBeNull();
     });
   });
 });

--- a/test/unit/status-badge.spec.ts
+++ b/test/unit/status-badge.spec.ts
@@ -19,13 +19,13 @@ describe('StatusBadge / getStatusInfo', () => {
 
     it('maps SENT to "Emise" with the sent utility', () => {
       const info = getStatusInfo('invoice', 'SENT');
-      expect(info.label).toBe('Emise');
+      expect(info.label).toBe('Émise');
       expect(info.className).toBe('status-badge-sent');
     });
 
     it('maps PAID to "Payee" with the paid utility', () => {
       const info = getStatusInfo('invoice', 'PAID');
-      expect(info.label).toBe('Payee');
+      expect(info.label).toBe('Payée');
       expect(info.className).toBe('status-badge-paid');
     });
 
@@ -50,7 +50,7 @@ describe('StatusBadge / getStatusInfo', () => {
 
     it('maps CONFIRMED to "Confirmee"', () => {
       const info = getStatusInfo('registration', 'CONFIRMED');
-      expect(info.label).toBe('Confirmee');
+      expect(info.label).toBe('Confirmée');
       expect(info.className).toBe('status-badge-confirmed');
     });
 
@@ -62,17 +62,17 @@ describe('StatusBadge / getStatusInfo', () => {
 
     it('maps CANCELLED to "Annulee"', () => {
       const info = getStatusInfo('registration', 'CANCELLED');
-      expect(info.label).toBe('Annulee');
+      expect(info.label).toBe('Annulée');
       expect(info.className).toBe('status-badge-cancelled');
     });
   });
 
   describe('attendance', () => {
     it('covers the four attendance statuses', () => {
-      expect(getStatusInfo('attendance', 'PRESENT').label).toBe('Present');
+      expect(getStatusInfo('attendance', 'PRESENT').label).toBe('Présent');
       expect(getStatusInfo('attendance', 'ABSENT').label).toBe('Absent');
       expect(getStatusInfo('attendance', 'LATE').label).toBe('En retard');
-      expect(getStatusInfo('attendance', 'EXCUSED').label).toBe('Excuse');
+      expect(getStatusInfo('attendance', 'EXCUSED').label).toBe('Excusé');
     });
 
     it('uses dedicated utilities for each attendance status', () => {
@@ -86,8 +86,8 @@ describe('StatusBadge / getStatusInfo', () => {
   describe('creditNote', () => {
     it('handles DRAFT / SENT / CANCELLED used in the current schema', () => {
       expect(getStatusInfo('creditNote', 'DRAFT').label).toBe('Brouillon');
-      expect(getStatusInfo('creditNote', 'SENT').label).toBe('Emis');
-      expect(getStatusInfo('creditNote', 'CANCELLED').label).toBe('Annule');
+      expect(getStatusInfo('creditNote', 'SENT').label).toBe('Émis');
+      expect(getStatusInfo('creditNote', 'CANCELLED').label).toBe('Annulé');
     });
 
     it('supports forward-compat ISSUED and APPLIED statuses', () => {
@@ -99,9 +99,9 @@ describe('StatusBadge / getStatusInfo', () => {
   describe('camp', () => {
     it('covers the four camp statuses', () => {
       expect(getStatusInfo('camp', 'DRAFT').label).toBe('Brouillon');
-      expect(getStatusInfo('camp', 'PUBLISHED').label).toBe('Publie');
-      expect(getStatusInfo('camp', 'CLOSED').label).toBe('Ferme');
-      expect(getStatusInfo('camp', 'CANCELLED').label).toBe('Annule');
+      expect(getStatusInfo('camp', 'PUBLISHED').label).toBe('Publié');
+      expect(getStatusInfo('camp', 'CLOSED').label).toBe('Fermé');
+      expect(getStatusInfo('camp', 'CANCELLED').label).toBe('Annulé');
     });
   });
 
@@ -116,7 +116,7 @@ describe('StatusBadge / getStatusInfo', () => {
 
   describe('refund', () => {
     it('handles IMMEDIATE_REFUND and FUTURE_CREDIT', () => {
-      expect(getStatusInfo('refund', 'IMMEDIATE_REFUND').label).toBe('Remboursement immediat');
+      expect(getStatusInfo('refund', 'IMMEDIATE_REFUND').label).toBe('Remboursement immédiat');
       expect(getStatusInfo('refund', 'FUTURE_CREDIT').label).toBe('Avoir futur');
     });
   });


### PR DESCRIPTION
## Summary

Two technical debts resolved:

1. **TD-012**: The FEC export now correctly names files per article A47 A-1 of the LPF (`SIRENFECAAAAMMJJ.txt` instead of `FEC_AAAAMMJJ_AAAAMMJJ.txt`). The SIREN is stored once in settings and used to name the file; it does not appear in the file content.

2. **TD-013**: Consolidated all status badge rendering to use the centralized `<StatusBadge />` component, eliminating six duplicate local `getStatusBadge()` helpers and fixing color calibration issues.

## Key Changes

### TD-012: FEC SIREN Naming (Regulatory Compliance)

- **New setting**: `accounting.fec_siren` (9 digits, optional) in the Comptabilité tab of Settings
- **Helper functions** (`server/helpers/settings.ts`):
  - `normalizeSiren()`: Accepts raw digits, JSON-stringified values, and readability separators (spaces, dots); returns 9 digits or null
  - `getFecSiren()`: Reads the setting from the database
- **Router logic** (`server/routers/fec.ts`):
  - `buildFECFilename()`: Generates `SIRENFECAAAAMMJJ.txt` (AAAAMMJJ = end date) when SIREN is present; falls back to legacy `FEC_AAAAMMJJ_AAAAMMJJ.txt` when absent
  - Validates typed SIREN and rejects malformed input with `BAD_REQUEST` rather than silently producing a non-compliant filename
  - Returns `siren` in the output so the UI knows what was actually used
- **UI** (`app/dashboard/admin/fec/export/page.tsx`):
  - Pre-fills the SIREN field from settings via `trpc.settings.getByCategory`
  - Displays the generated filename and warns if no SIREN is configured
  - Validates SIREN client-side (9 digits, tolerates separators)
- **Export remains possible without SIREN** under the legacy name, with a non-compliance warning; exports are never blocked for naming reasons

### TD-013: Centralized Status Badges

- **Removed six duplicate helpers**:
  - `components/admin/camps/columns.tsx`
  - `components/staff/camps/columns.tsx`
  - `components/camps/camp-detail-page.tsx`
  - `components/admin/refunds/columns.tsx`
  - `components/staff/refunds/columns.tsx`
  - `components/admin/refunds/refund-details.tsx`
- **All six sites now call** `<StatusBadge type="..." status="..." />`
- **Accented labels** in `components/shared/status-badge.tsx`:
  - "Émise" (was "Emise"), "Payée" (was "Payee"), "Annulée" (was "Annulee"), etc.
  - Fixes display across invoice, registration, attendance, and refund badges
- **Refund method** now uses `StatusBadge` instead of raw enum display

## Testing

- Unit tests for `normalizeSiren()` and `getFecSiren()` in `test/unit/settings.helper.spec.ts`
- Comprehensive FEC filename tests in `test/unit/fec.spec.ts` (7 new test cases)
- Status badge label tests updated in `test/unit/status-badge.spec.ts`
- Smoke test verifies SIREN naming in `test/e2e-smoke/smoke.mjs`

## Documentation

- `docs/dette-technique.md` updated with TD-012 and TD-013 resolutions
- `CLAUDE.md` updated with SIREN naming and status badge conventions
- `CHANGELOG.md` documents both fixes

https://claude.ai/code/session_01RszLPwfcfngLMgM28DBvZQ