### PR TITLE
Deux renvois TD cassés par la renumérotation de la fusion #28 / #29

### DIFF
--- a/components/parent/registration-form.tsx
+++ b/components/parent/registration-form.tsx
@@ -29,7 +29,7 @@ import { formatDate } from '@/lib/utils';
 // et le controle de compatibilite qu'elles alimentaient sont retires
 // (sixieme passe de code mort) : la garde `minAge === undefined` sortait a
 // chaque appel, le message d'erreur n'a jamais pu s'afficher. Le besoin, lui,
-// reste ouvert — voir TD-023 dans docs/dette-technique.md.
+// reste ouvert — voir TD-024 dans docs/dette-technique.md.
 interface RegistrationFormProps {
   campId: string;
   campName: string;

--- a/docs/dette-technique.md
+++ b/docs/dette-technique.md
@@ -365,7 +365,7 @@ trace du manque ; les garder sans les tracer laisse croire qu'elles servent.
 | `attendances.list` | vue des présences côté PARENT (le pointage STAFF passe par `getGridForCamp`) |
 | `attendances.delete`, `attendances.getStatistics` | correction d'un pointage, statistiques de présence |
 | `registrations.getAvailableCredits` | affichage des avoirs disponibles (seul `pnpm smoke` l'appelle) |
-| `staffDocuments.getById` | fiche d'un document du personnel — l'écran ne liste et ne supprime (ajoutée par la 6ᵉ passe ; voir aussi TD-024, ce module n'a pas non plus de téléversement) |
+| `staffDocuments.getById` | fiche d'un document du personnel — l'écran ne liste et ne supprime (ajoutée par la 6ᵉ passe ; voir aussi TD-025, ce module n'a pas non plus de téléversement) |
 
 **Point d'attention immédiat** : les deux écrans de paramétrage
 (`/dashboard/admin/settings/camp-types` et `.../payment-methods`) affichent


### PR DESCRIPTION
## Le défaut

Les PR #28 et #29 ont été écrites en parallèle et ont toutes deux ajouté des
fiches de dette. La fusion a renuméroté celles de #29 pour éviter la collision :

| Fiche | Avant | Après |
|---|---|---|
| Bornes d'âge d'un camp | TD-023 | **TD-024** |
| Téléversement : `/api/upload/*` sans route (P1) | TD-024 | **TD-025** |
| Duplication ADMIN / STAFF | TD-025 | **TD-026** |

Les titres et `CLAUDE.md` ont suivi ; **deux renvois non**. Ils pointent
aujourd'hui sur une fiche qui traite d'autre chose :

- `components/parent/registration-form.tsx:32` renvoie à TD-023, qui désigne
  désormais « `components/ui/` : 18 sous-composants shadcn jamais rendus »
  (apportée par #28). Le besoin de bornes d'âge est TD-024.
- La ligne `staffDocuments.getById` de la table de TD-010
  (`docs/dette-technique.md`) renvoie à TD-024 pour l'absence de téléversement.
  C'est TD-025.

Ce sont deux caractères, mais c'est le mécanisme même sur lequel ce dépôt
s'appuie : un commentaire de code qui envoie le lecteur vers la mauvaise fiche
coûte plus cher qu'un commentaire absent.

## Vérifications

- `pnpm typecheck` — propre
- `pnpm test` — 979 tests verts
- `pnpm build` — vérifié sur l'arbre fusionné avant cette correction (l'échec du
  déploiement de prévisualisation Vercel sur #29 ne se reproduit pas en local :
  la compilation de production aboutit)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyQYrnVu1tCnKg2QgvfoAv)_