### PR TITLE
TD-025 : livre les routes de téléversement, et fiabilise la chaîne de build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,17 @@ on:
 
 jobs:
   quality:
-    name: Lint, typecheck & tests
+    name: Lint, typecheck, tests & build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Pas de `version:` ici — la version fait autorité dans le champ
+      # `packageManager` de package.json, pour que le CI, les postes de dev et
+      # le build Vercel installent avec le MÊME pnpm.
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -38,3 +39,18 @@ jobs:
 
       - name: Unit tests (vitest)
         run: pnpm test
+
+      # Le build était le seul filet manquant : les tests sont mockés et le
+      # typecheck ne voit pas les erreurs de rendu/prérendu de Next. Une
+      # régression de build ne se serait vue qu'au déploiement — et les
+      # déploiements de preview Vercel échouent pour une raison d'environnement
+      # (docs/deploiement.md § « Échecs de déploiement en preview »), donc
+      # personne ne la rattrapait.
+      #
+      # Aucune variable d'environnement n'est fournie volontairement : toutes
+      # les pages du tableau de bord sont dynamiques, le build ne doit jamais
+      # dépendre d'un accès base ou d'un secret. Si cette étape se met à
+      # réclamer une variable, c'est qu'une page s'est mise à interroger la
+      # base au prérendu.
+      - name: Build (next build)
+        run: pnpm build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,63 @@ Format inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
 
 ## [Unreleased]
 
+### Added — téléversement des fichiers, enfin branché (TD-025, 2026-08-19)
+
+Trois appels `fetch` du navigateur visaient des routes qui n'existaient dans
+aucun commit : le logo de l'association et les documents PDF d'un enfant étaient
+**impossibles à téléverser** depuis la refonte, avec un « Erreur lors de
+l'upload » pour seule explication. Les routes existent maintenant.
+
+- **`POST` / `DELETE /api/upload/logo`** (ADMIN) — validation MIME et taille
+  refaite côté serveur, téléversement, et suppression restreinte au blob dont
+  l'URL est **celle enregistrée** dans les réglages : sans cette comparaison, la
+  route aurait accepté d'effacer n'importe quel objet du store (PDF de facture,
+  document d'enfant) sur simple URL.
+- **`POST /api/upload/child-documents`** (PARENT pour ses enfants, STAFF/ADMIN)
+  — valide PDF + 5 Mo, applique la règle d'accès enfant puis crée la ligne
+  `child_documents`. Un `File` ne traverse pas tRPC/superjson : la création vit
+  dans la route, pas dans une procédure.
+
+Deux pièges traités, chacun avec son test (`test/unit/upload-routes.spec.ts`,
+17 cas) : le blob du logo prend un nom aléatoire — à nom fixe, la suppression du
+logo précédent que fait `settings.setLogoUrl` (TD-006) effacerait le fichier
+tout juste téléversé — et un échec d'écriture en base annule le blob déjà
+téléversé, pendant amont de TD-006.
+
+La règle d'accès à un enfant est désormais partagée
+(`server/helpers/child-access.helper.ts`) entre le routeur et la route : une
+seule définition, un refus 404 indistinct des deux côtés.
+
+**Reste ouvert** : les documents du personnel n'ont toujours pas de dépôt — mais
+aucun écran ne le demande, c'est une fonctionnalité à spécifier, pas un appel
+mort. Et aucune campagne (`pnpm smoke`, `pnpm recette`) ne couvre encore un
+téléversement réel.
+
+### Changed — chaîne de build : une version de pnpm, et un build en CI (2026-08-19)
+
+- **`packageManager: pnpm@9.15.9`** dans `package.json`. Trois environnements
+  installaient avec trois pnpm différents (Vercel 9, CI 10, postes de dev 11) ;
+  le champ est lu par les trois, et le workflow n'épingle plus de version.
+- **`pnpm-workspace.yaml` supprimé** : il avait été commité avec les valeurs
+  modèles de `pnpm approve-builds` (« set this to true or false »), illisibles
+  pour pnpm — donc aucun script d'installation autorisé, donc pas de
+  `prisma generate` au `postinstall`. Conséquences et marche à suivre en cas de
+  passage à pnpm ≥ 10 : `docs/deploiement.md`.
+- **`next build` ajouté au CI.** Les tests sont mockés et `tsc` ne voit pas le
+  rendu : rien ne rattrapait une régression de build, d'autant que les
+  déploiements de preview Vercel échouent tous pour une raison d'environnement.
+
+### Investigated — échecs de déploiement Vercel (2026-08-19)
+
+Les previews échouent **une seconde** après création (statuts GitHub à l'appui) :
+ce n'est pas un build qui casse mais un déploiement refusé avant de démarrer. Ni
+le code (build local vert, PR de documentation seule en échec) ni les variables
+d'environnement du build (aucune n'est nécessaire : toutes les pages du tableau
+de bord sont dynamiques) n'expliquent l'échec. Les trois causes restantes sont
+côté projet Vercel et se départagent avec `vercel inspect --logs` — procédure et
+commandes dans `docs/deploiement.md` § « Échecs de déploiement en preview ».
+
+
 ### Removed — sixième passe de code mort (2026-08-18)
 
 Passe complète après celles des 10, 11, 14 et 15 août. Contrôles rejoués sur

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,22 @@ base. Deux regles :
   l'utilisateur a supprime ne doit pas ressusciter parce que Vercel Blob a
   hoquete.
 
+### Televerser un fichier : route HTTP, nom unique, blob annulable (TD-025)
+Un `File` ne traverse pas tRPC/superjson : les televersements passent par des
+routes `app/api/upload/*`, qui portent AUSSI la creation de la ligne en base
+(il n'y a pas de `childDocuments.create`). Trois regles :
+- **valider MIME et taille cote serveur** — la validation des composants
+  (`image-upload.tsx`, `document-upload.tsx`) n'est qu'un confort, elle se
+  contourne ;
+- **nom de blob unique** (`logo-<uuid>.png`) pour le logo : `settings.setLogoUrl`
+  supprime le blob precedent (TD-006), et a nom fixe les deux URL seraient
+  identiques — il effacerait le fichier qui vient d'etre televerse ;
+- **blob d'abord, ligne ensuite, et blob annule si la ligne echoue** : c'est le
+  pendant amont de TD-006 (un objet public et facture sans aucune reference).
+
+La regle d'acces a un enfant est partagee entre le routeur et la route dans
+`server/helpers/child-access.helper.ts` — ne pas la redupliquer.
+
 ### Envoi d'email (TD-008)
 `server/services/email.service.ts` est le seul point d'envoi (API REST Resend).
 La cle vit dans l'environnement (`RESEND_API_KEY`), l'identite d'expedition dans
@@ -214,7 +230,7 @@ Pour chaque router :
 ## Documents
 
 - `docs/deploiement.md` — topologie Vercel/Neon, vars d'env, procedure de migration, incident 2025-11.
-- `docs/dette-technique.md` — registre de dette (OPEN : TD-001 typage any des mappers ; TD-005 triggers legacy absents du depot — « dernier parent » et `payment_status` ; TD-009 aucune limitation de debit sur l'authentification ; TD-010 procedures tRPC sans ecran ; TD-011 auto-inscription parent sans serveur ; TD-014 route de presence en double, sans lien ; TD-015 modeles NextAuth `Session`/`VerificationToken` inutilises ; TD-016 aucun ecran « mon compte » self-service ; TD-017 ecran d'habilitations `/dashboard/admin/users` hors navigation ; TD-018 colonnes Prisma jamais lues ni ecrites ; TD-019 `isPasswordStrong` sans appelant serveur ; TD-020 `prisma/reset-data.sql` orphelin et trompeur ; TD-021 `user.name`/`user.emailVerified` transportes sans lecteur ; TD-022 douze formatages de date dupliques ; TD-023 sous-composants shadcn jamais rendus dans `components/ui/` ; TD-024 aucune borne d'age sur un camp ; **TD-025 trois appels `/api/upload/*` sans route (logo et documents non televersables — P1)** ; TD-026 quatre ecrans dupliques entre ADMIN et STAFF ; TD-027 pointage de presence : trois champs d'entree qu'aucun ecran ne remplit. DONE : TD-002 factures legacy 0 XPF ; TD-003 divergence des deux vues du solde d'un avoir ; TD-004 reserve du pied de page PDF ; TD-006 blobs orphelins ; TD-007 PDF d'avoir cable ; TD-008 envoi d'email implemente ; TD-012 SIREN du FEC cable ; TD-013 statuts affiches via StatusBadge ; TD-A2 couverture PDF facture).
+- `docs/dette-technique.md` — registre de dette (OPEN : TD-001 typage any des mappers ; TD-005 triggers legacy absents du depot — « dernier parent » et `payment_status` ; TD-009 aucune limitation de debit sur l'authentification ; TD-010 procedures tRPC sans ecran ; TD-011 auto-inscription parent sans serveur ; TD-014 route de presence en double, sans lien ; TD-015 modeles NextAuth `Session`/`VerificationToken` inutilises ; TD-016 aucun ecran « mon compte » self-service ; TD-017 ecran d'habilitations `/dashboard/admin/users` hors navigation ; TD-018 colonnes Prisma jamais lues ni ecrites ; TD-019 `isPasswordStrong` sans appelant serveur ; TD-020 `prisma/reset-data.sql` orphelin et trompeur ; TD-021 `user.name`/`user.emailVerified` transportes sans lecteur ; TD-022 douze formatages de date dupliques ; TD-023 sous-composants shadcn jamais rendus dans `components/ui/` ; TD-024 aucune borne d'age sur un camp ; TD-026 quatre ecrans dupliques entre ADMIN et STAFF ; TD-027 pointage de presence : trois champs d'entree qu'aucun ecran ne remplit. DONE : TD-002 factures legacy 0 XPF ; TD-003 divergence des deux vues du solde d'un avoir ; TD-004 reserve du pied de page PDF ; TD-006 blobs orphelins ; TD-007 PDF d'avoir cable ; TD-008 envoi d'email implemente ; TD-012 SIREN du FEC cable ; TD-013 statuts affiches via StatusBadge ; TD-025 routes `/api/upload/*` livrees ; TD-A2 couverture PDF facture).
 - `docs/stories/BACKLOG.md` — backlog produit + **backlog MIKADO livre le 2026-08-09** (7 US, arbitrages US-FACT-02 tranches) + **retours de recette livres le 2026-08-10** (4 US : PDF facture, selecteur d'avoir, suppression de parent).
 - `docs/test-evidence/recette-v2.0.1/` — recette visuelle Playwright (19/19 PASS, `pnpm recette`) + rapport de preuve.
 - `CHANGELOG.md` — journal des livraisons (v2.0.0 premiere prod de la refonte + v2.0.1 correctifs campagne smoke, 2026-07-06).

--- a/app/api/upload/child-documents/route.ts
+++ b/app/api/upload/child-documents/route.ts
@@ -1,0 +1,142 @@
+/**
+ * Documents PDF d'un enfant — televersement (TD-025).
+ *
+ * `components/ui/document-upload.tsx` poste ici un `multipart/form-data`
+ * (`file`, `childId`, `description?`) : un `File` ne traverse pas
+ * tRPC/superjson, d'ou une route HTTP. Le routeur `childDocuments` ne porte
+ * que list/count/delete — c'est cette route qui cree la ligne.
+ *
+ * Ordre volontaire : blob d'abord, ligne ensuite. Si l'ecriture en base echoue,
+ * le blob est supprime (best effort) pour ne pas laisser d'objet facture et
+ * public sans aucune reference — pendant amont de TD-006.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/server/db';
+import {
+  uploadToStorage,
+  deleteFromStorageBestEffort,
+} from '@/lib/storage/blob-storage';
+import { hasChildAccess } from '@/server/helpers/child-access.helper';
+
+// Memes valeurs que `components/ui/document-upload.tsx`.
+const MAX_SIZE = 5 * 1024 * 1024; // 5 Mo
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
+  }
+
+  let file: File | null = null;
+  let childId = '';
+  let description: string | null = null;
+  try {
+    const formData = await req.formData();
+    const entry = formData.get('file');
+    file = entry instanceof File ? entry : null;
+    childId = String(formData.get('childId') ?? '');
+    const rawDescription = formData.get('description');
+    description =
+      typeof rawDescription === 'string' && rawDescription.trim()
+        ? rawDescription.trim()
+        : null;
+  } catch {
+    return NextResponse.json({ error: 'Requête invalide' }, { status: 400 });
+  }
+
+  if (!UUID_RE.test(childId)) {
+    return NextResponse.json({ error: 'Enfant invalide' }, { status: 400 });
+  }
+  if (!file) {
+    return NextResponse.json({ error: 'Aucun fichier reçu' }, { status: 400 });
+  }
+  if (file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: 'Format non autorisé. Seuls les fichiers PDF sont acceptés.' },
+      { status: 400 },
+    );
+  }
+  if (file.size === 0) {
+    return NextResponse.json({ error: 'Fichier vide' }, { status: 400 });
+  }
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json(
+      { error: 'Fichier trop volumineux. Taille maximale : 5MB' },
+      { status: 400 },
+    );
+  }
+
+  // Meme regle d'acces que les procedures tRPC : un parent n'atteint que ses
+  // propres enfants, et le refus est un 404 indistinct.
+  const allowed = await hasChildAccess(
+    prisma,
+    session.user.id,
+    session.user.role ?? 'PARENT',
+    childId,
+  );
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Enfant non trouvé ou accès refusé' },
+      { status: 404 },
+    );
+  }
+
+  const filename = `${randomUUID()}.pdf`;
+  const originalFilename = file.name?.trim() || filename;
+
+  let uploadedUrl: string;
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const { url } = await uploadToStorage(buffer, {
+      pathname: `child-documents/${childId}/${filename}`,
+      contentType: 'application/pdf',
+    });
+    uploadedUrl = url;
+  } catch (error) {
+    console.error('[upload/child-documents] Televersement impossible', error);
+    return NextResponse.json(
+      { error: "Le téléversement a échoué. Le stockage est-il configuré ?" },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const document = await prisma.childDocument.create({
+      data: {
+        childId,
+        filename,
+        originalFilename,
+        fileUrl: uploadedUrl,
+        mimeType: 'application/pdf',
+        fileSize: file.size,
+        description,
+        uploadedBy: session.user.id,
+      },
+    });
+
+    return NextResponse.json({
+      id: document.id,
+      childId: document.childId,
+      filename: document.filename,
+      originalFilename: document.originalFilename,
+      fileUrl: document.fileUrl,
+      fileSize: document.fileSize,
+      description: document.description,
+    });
+  } catch (error) {
+    console.error(
+      '[upload/child-documents] Enregistrement impossible, blob annule',
+      error,
+    );
+    await deleteFromStorageBestEffort(uploadedUrl, 'document enfant orphelin');
+    return NextResponse.json(
+      { error: "L'enregistrement du document a échoué" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/upload/logo/route.ts
+++ b/app/api/upload/logo/route.ts
@@ -1,0 +1,134 @@
+/**
+ * Logo de l'association — televersement et suppression du blob (TD-025).
+ *
+ * `components/ui/image-upload.tsx` (POST) et l'ecran `/dashboard/admin/settings`
+ * (DELETE) appellent cette route depuis le navigateur : un `File` ne traverse
+ * pas tRPC/superjson, d'ou une route HTTP plutot qu'une procedure.
+ *
+ * La route ne fait QUE manipuler le store. L'enregistrement de l'URL dans
+ * `app_settings.organization.logo_url` reste porte par `settings.setLogoUrl` /
+ * `settings.deleteLogoUrl`, appeles par l'ecran juste apres.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import { auth } from '@/lib/auth';
+import { prisma } from '@/server/db';
+import {
+  uploadToStorage,
+  deleteFromStorageBestEffort,
+} from '@/lib/storage/blob-storage';
+import { parseLogoValue } from '@/server/helpers/settings';
+
+// Memes valeurs que `components/ui/image-upload.tsx` : la validation client
+// donne le message immediat, celle-ci fait autorite (le client est contournable).
+const ACCEPTED_TYPES: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/svg+xml': 'svg',
+};
+const MAX_SIZE = 2 * 1024 * 1024; // 2 Mo
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
+  }
+  if (session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 403 });
+  }
+
+  let file: File | null = null;
+  try {
+    const formData = await req.formData();
+    const entry = formData.get('file');
+    file = entry instanceof File ? entry : null;
+  } catch {
+    return NextResponse.json({ error: 'Requête invalide' }, { status: 400 });
+  }
+
+  if (!file) {
+    return NextResponse.json({ error: 'Aucun fichier reçu' }, { status: 400 });
+  }
+
+  const extension = ACCEPTED_TYPES[file.type];
+  if (!extension) {
+    return NextResponse.json(
+      { error: 'Format non autorisé. Formats acceptés : PNG, JPEG, SVG' },
+      { status: 400 },
+    );
+  }
+  if (file.size === 0) {
+    return NextResponse.json({ error: 'Fichier vide' }, { status: 400 });
+  }
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json(
+      { error: 'Fichier trop volumineux. Taille maximale : 2.0MB' },
+      { status: 400 },
+    );
+  }
+
+  // Nom unique OBLIGATOIRE : `settings.setLogoUrl` supprime le blob precedent
+  // apres avoir enregistre le nouveau (TD-006). Avec un pathname fixe, les deux
+  // URL seraient identiques et cette suppression effacerait le logo qu'on vient
+  // de televerser.
+  const pathname = `organization/logo-${randomUUID()}.${extension}`;
+
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const { url } = await uploadToStorage(buffer, {
+      pathname,
+      contentType: file.type,
+    });
+    return NextResponse.json({ url });
+  } catch (error) {
+    console.error('[upload/logo] Televersement impossible', error);
+    return NextResponse.json(
+      { error: "Le téléversement a échoué. Le stockage est-il configuré ?" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Non authentifié' }, { status: 401 });
+  }
+  if (session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Non autorisé' }, { status: 403 });
+  }
+
+  let url: unknown;
+  try {
+    const body = await req.json();
+    url = (body as { url?: unknown })?.url;
+  } catch {
+    return NextResponse.json({ error: 'Requête invalide' }, { status: 400 });
+  }
+
+  if (typeof url !== 'string' || !url.trim()) {
+    return NextResponse.json({ error: 'URL manquante' }, { status: 400 });
+  }
+
+  // Garde-fou : cette route ne peut effacer QUE le logo enregistre. Sans cette
+  // comparaison, un compte ADMIN compromis pourrait faire supprimer n'importe
+  // quel objet du store (PDF de facture, document d'enfant) via son URL.
+  const setting = await prisma.appSetting.findUnique({
+    where: { category_key: { category: 'organization', key: 'logo_url' } },
+  });
+  const storedUrl = parseLogoValue(setting?.value);
+
+  if (!storedUrl || storedUrl !== url) {
+    return NextResponse.json(
+      { error: "L'URL ne correspond pas au logo enregistré" },
+      { status: 400 },
+    );
+  }
+
+  // Best effort (TD-006) : un store injoignable ne doit pas empecher l'ecran
+  // de retirer ensuite l'URL des settings.
+  await deleteFromStorageBestEffort(storedUrl, 'logo supprimé');
+
+  return NextResponse.json({ success: true });
+}

--- a/docs/deploiement.md
+++ b/docs/deploiement.md
@@ -1,6 +1,6 @@
 # Déploiement — ALVM (Vercel + Neon)
 
-> Dernière mise à jour : 2026-08-16 (§ Données de référence — seeds)
+> Dernière mise à jour : 2026-08-19 (§ Échecs de déploiement en preview ; version pnpm figée)
 
 ## Topologie
 
@@ -11,7 +11,7 @@
 | Repo GitHub | `innovia-nc/alvm-vercel`, branche de prod `master` |
 | BDD | **Neon PostgreSQL 17** via l'intégration Vercel ↔ Neon (⚠️ pas Supabase) |
 | Stockage fichiers | Vercel Blob (`BLOB_READ_WRITE_TOKEN`) |
-| Node / build | 22.x, défauts framework Next.js (pnpm auto-détecté via `pnpm-lock.yaml`) |
+| Node / build | 22.x, défauts framework Next.js ; **pnpm figé par `packageManager` dans `package.json`** (voir ci-dessous) |
 
 ## Variables d'environnement (Vercel)
 
@@ -29,6 +29,71 @@ Email. Seul le domaine d'envoi doit être vérifié côté Resend.
 
 Vars legacy présentes mais inutilisées par le code : `NEXTAUTH_*`, `STACK_*`,
 `PG*`, `NEON_PROJECT_ID`, `DATABASE_URL` — nettoyage possible après stabilité.
+
+## Version de pnpm — une seule autorité
+
+`package.json` porte `"packageManager": "pnpm@9.15.9"`. Avant le 2026-08-19,
+trois environnements installaient avec trois pnpm différents : Vercel en 9
+(déduit de `lockfileVersion: 9.0`), le CI GitHub en 10 (épinglé dans le
+workflow), les postes de dev en 11. Le champ `packageManager` est lu par les
+trois — le workflow n'épingle donc plus de version, et pnpm bascule tout seul
+sur la bonne sur un poste de dev.
+
+Ce qui avait été commité entre-temps : un `pnpm-workspace.yaml` contenant les
+valeurs **modèles** de `pnpm approve-builds` (« set this to true or false »).
+Illisible pour pnpm, donc aucun script d'installation autorisé, donc pas de
+`prisma generate` au `postinstall` — le fichier est supprimé.
+
+⚠️ **Si un jour la version est montée à pnpm ≥ 10** : les scripts
+d'installation redeviennent bloqués par défaut. Il faut alors déclarer
+`onlyBuiltDependencies` (`@prisma/client`, `@prisma/engines`, `prisma`,
+`esbuild`, `sharp`, `unrs-resolver`) dans un `pnpm-workspace.yaml` — le champ
+`pnpm` de `package.json` n'est **plus lu** par pnpm 10+ (il est ignoré en
+silence). Sans cela le build échoue sur un client Prisma absent.
+
+## Échecs de déploiement en preview (constat 2026-08-19)
+
+**Symptôme** : sur `alvm-v2`, la production se déploie normalement mais **toutes
+les previews de PR échouent** — y compris des PR qui ne touchent que des
+fichiers Markdown, et y compris les #26/#27 mergées ainsi. Le projet
+`alvm-vercel` (team `ifingos-projects`, branché sur le même repo) échoue lui
+aussi, sur `master`.
+
+**Ce qui est établi, et ce qui l'exclut** :
+
+| Piste | Verdict |
+|---|---|
+| Régression de code | **Exclue** — `pnpm build` passe en local, et une PR de documentation seule échoue aussi. |
+| Build qui réclamerait une variable d'environnement | **Exclue** — le build tourne sans aucune variable : toutes les pages du tableau de bord sont dynamiques (`ƒ`), rien n'interroge la base au prérendu. Une étape `next build` a été ajoutée au CI pour que ce fait reste vrai. |
+| Étape d'installation (pnpm) | **Improbable** — l'échec arrive **une seconde** après la création du déploiement (statuts GitHub : créé à 00:13:36, `failure` à 00:13:37). Une installation puis un build prennent des minutes. |
+
+Un échec en une seconde n'est pas un build qui casse : c'est un déploiement
+**refusé avant de démarrer**. Les causes habituelles sont toutes côté projet
+Vercel, pas côté dépôt :
+
+1. une variable d'environnement de l'environnement *Preview* qui référence un
+   secret/store supprimé (cas classique après un débranchement de l'intégration
+   Neon : « references Secret … which does not exist ») ;
+2. un quota ou une facturation de l'équipe qui interdit les déploiements de
+   preview ;
+3. une intégration (Neon) qui échoue à créer la branche de base de données du
+   preview.
+
+**Diagnostic — trois commandes, à lancer avec un compte Vercel** (le dépôt ne
+porte aucun jeton, ces commandes ne peuvent pas être jouées depuis le CI) :
+
+```bash
+npx vercel login
+npx vercel inspect dpl_5w3TtrEmDsGV5q6qsGWDiCQwD4iY --logs   # dernier preview en échec
+npx vercel env ls preview                                    # comparer avec `vercel env ls production`
+```
+
+La première ligne de sortie de `inspect` donne le motif exact ; c'est elle qui
+départage les trois causes ci-dessus. Tant qu'elle n'est pas lue, toute
+modification du dépôt serait une correction à l'aveugle — d'où le choix de
+n'avoir rien changé au code applicatif pour ce point, et d'avoir seulement
+ajouté le filet manquant (build en CI) et supprimé la vraie anomalie trouvée en
+chemin (le `pnpm-workspace.yaml` modèle).
 
 ## Déployer
 

--- a/docs/dette-technique.md
+++ b/docs/dette-technique.md
@@ -705,7 +705,7 @@ colonnes sur `camps`, leur saisie dans le formulaire d'ACM, le refus côté
 `registrations.create` (une validation qui ne vit que dans le navigateur ne
 protège rien), puis seulement l'aide à la saisie côté parent.
 
-## TD-025 — Téléversement : trois appels `/api/upload/*`, aucune route en face — P1 — OPEN
+## TD-025 — Téléversement : trois appels `/api/upload/*`, aucune route en face — P1 — DONE (2026-08-19)
 
 **Constat (2026-08-17, sixième passe de code mort)** : trois appels `fetch` du
 client visent des routes qui **n'existent dans aucun commit du dépôt** —
@@ -745,11 +745,47 @@ facture), plus une procédure `childDocuments.create` / `staffDocuments.create`
 qui enregistre la ligne. Supprimer les écrans à la place ferait disparaître une
 fonctionnalité attendue au lieu de la livrer.
 
-**Résolution cible** : livrer les routes manquantes et leurs procédures, et
-ajouter un critère de recette par téléversement (logo, document d'enfant,
-document du personnel) — l'absence de couverture est ce qui a permis au défaut
-de traverser deux mises en production. En attendant, TD-006 s'applique déjà à la
-suppression : la ligne d'abord, le blob ensuite, best effort.
+**✅ Corrigé le 2026-08-19** — les deux routes existent, avec leurs tests
+(`test/unit/upload-routes.spec.ts`, 17 cas) :
+
+| Route | Habilitation | Ce qu'elle fait |
+|-------|--------------|-----------------|
+| `POST /api/upload/logo` | ADMIN | valide le MIME (PNG/JPEG/SVG) et la taille (2 Mo) **côté serveur**, téléverse, retourne `{ url }`. L'enregistrement du réglage reste à `settings.setLogoUrl`, appelé par l'écran juste après. |
+| `DELETE /api/upload/logo` | ADMIN | ne supprime que le blob dont l'URL **est celle enregistrée** dans `app_settings.organization.logo_url` ; suppression best effort (TD-006). |
+| `POST /api/upload/child-documents` | PARENT (ses enfants) / STAFF / ADMIN | valide PDF + 5 Mo, applique la règle d'accès enfant, téléverse puis crée la ligne `child_documents`. |
+
+Un `File` ne traverse pas tRPC/superjson : ce sont des routes HTTP, pas des
+procédures — d'où l'absence de `childDocuments.create`, la route porte la
+création.
+
+Deux garde-fous que la reprise a rendus nécessaires, chacun couvert par un test :
+
+- **le nom du blob du logo est aléatoire** (`organization/logo-<uuid>.<ext>`).
+  Avec un nom fixe, l'URL du nouveau logo serait identique à celle de l'ancien,
+  et la suppression du précédent que fait `settings.setLogoUrl` (TD-006)
+  effacerait le fichier tout juste téléversé ;
+- **la route de document annule son blob** si l'écriture en base échoue. C'est
+  le pendant amont de TD-006 : blob d'abord, ligne ensuite, donc c'est l'échec
+  de la ligne qui laisserait un objet public et facturé sans référence.
+
+La règle d'accès à un enfant, jusque-là privée au routeur, vit désormais dans
+`server/helpers/child-access.helper.ts` : le routeur et la route l'appliquent à
+l'identique, et le refus reste un 404 indistinct (un parent ne doit pas pouvoir
+distinguer « enfant inexistant » de « enfant qui n'est pas le sien »).
+
+**Reste ouvert — les documents du personnel, faute d'écran** : `staffDocuments`
+n'a toujours ni procédure ni route de création, mais **aucun code client ne les
+appelle** — `StaffDocumentsSection` liste, supprime et génère le PDF, sans zone
+de dépôt. Écrire la route sans l'écran créerait une procédure sans appelant
+(motif TD-010). C'est une fonctionnalité à spécifier, pas un appel mort à
+réparer.
+
+**Reste à faire — la couverture de recette** : ni `pnpm smoke` ni `pnpm recette`
+ne couvrent un téléversement ; c'est l'absence de ce critère qui a laissé le
+défaut traverser deux mises en production. Les tests ajoutés sont unitaires
+(store et base mockés) : ils prouvent les habilitations et les garde-fous, pas
+qu'un vrai blob Vercel est écrit. À ajouter à la prochaine recette : déposer un
+logo, déposer un PDF sur une fiche enfant.
 
 ## TD-026 — Les espaces ADMIN et STAFF dupliquent quatre écrans à l'identique — P3 — OPEN
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "alvm-vercel",
   "version": "2.0.1",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,0 @@
-allowBuilds:
-  '@prisma/client': set this to true or false
-  '@prisma/engines': set this to true or false
-  esbuild: set this to true or false
-  prisma: set this to true or false
-  sharp: set this to true or false
-  unrs-resolver: set this to true or false

--- a/server/helpers/child-access.helper.ts
+++ b/server/helpers/child-access.helper.ts
@@ -1,0 +1,38 @@
+import type { ExtendedPrismaClient } from '@/server/db';
+
+/**
+ * Droit d'acces a un enfant, partage par les procedures tRPC
+ * (`server/routers/child-documents.ts`) et par la route d'upload
+ * (`app/api/upload/child-documents/route.ts`).
+ *
+ * - STAFF / ADMIN : acces a tout enfant actif.
+ * - PARENT : uniquement les enfants auxquels il est rattache par
+ *   `children_parents`.
+ *
+ * Retourne un booleen plutot que de lever : l'appelant tRPC en fait un
+ * `TRPCError`, la route HTTP un 404. Deux appelants, une seule regle.
+ */
+export async function hasChildAccess(
+  prisma: ExtendedPrismaClient,
+  userId: string,
+  role: string,
+  childId: string,
+): Promise<boolean> {
+  if (role === 'STAFF' || role === 'ADMIN') {
+    const child = await prisma.child.findFirst({
+      where: { id: childId, deletedAt: null },
+      select: { id: true },
+    });
+    return child !== null;
+  }
+
+  const link = await prisma.childParent.findFirst({
+    where: {
+      parentId: userId,
+      childId,
+      child: { deletedAt: null },
+    },
+  });
+
+  return link !== null;
+}

--- a/server/helpers/settings.ts
+++ b/server/helpers/settings.ts
@@ -159,3 +159,21 @@ function parseJsonNumber(value: string): number {
     return Number.isFinite(n) ? n : NaN;
   }
 }
+
+/**
+ * Lit la valeur stockée du logo (JSON-stringified, ou en clair pour les lignes
+ * legacy) et retourne l'URL, ou `undefined` si la valeur est absente/vide.
+ *
+ * Partagé entre le routeur `settings` et la route `DELETE /api/upload/logo`,
+ * qui doit comparer l'URL demandée à celle réellement enregistrée avant
+ * d'effacer quoi que ce soit du store.
+ */
+export function parseLogoValue(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === 'string' && parsed.trim() ? parsed : undefined;
+  } catch {
+    return value;
+  }
+}

--- a/server/routers/child-documents.ts
+++ b/server/routers/child-documents.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { router, protectedProcedure } from '@/server/trpc/init';
 import { deleteFromStorageBestEffort } from '@/lib/storage/blob-storage';
+import { hasChildAccess } from '@/server/helpers/child-access.helper';
 
 const childDocumentSchema = z.object({
   id: z.string().uuid(),
@@ -18,9 +19,10 @@ const childDocumentSchema = z.object({
 });
 
 /**
- * Checks if a user has access to a child.
- * PARENT: must be linked via children_parents.
- * STAFF/ADMIN: always has access.
+ * Refus uniforme (404) : un parent ne doit pas pouvoir distinguer « enfant
+ * inexistant » de « enfant qui n'est pas le sien ». La regle d'acces elle-meme
+ * vit dans `server/helpers/child-access.helper.ts` — la route d'upload
+ * `/api/upload/child-documents` applique exactement la meme.
  */
 async function assertChildAccess(
   prisma: any,
@@ -28,27 +30,8 @@ async function assertChildAccess(
   role: string,
   childId: string,
 ): Promise<void> {
-  if (role === 'STAFF' || role === 'ADMIN') {
-    const child = await prisma.child.findFirst({
-      where: { id: childId, deletedAt: null },
-      select: { id: true },
-    });
-    if (!child) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'Enfant non trouvé' });
-    }
-    return;
-  }
-
-  // PARENT: check via children_parents
-  const link = await prisma.childParent.findFirst({
-    where: {
-      parentId: userId,
-      childId,
-      child: { deletedAt: null },
-    },
-  });
-
-  if (!link) {
+  const allowed = await hasChildAccess(prisma, userId, role, childId);
+  if (!allowed) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Enfant non trouvé ou accès refusé' });
   }
 }

--- a/server/routers/settings.ts
+++ b/server/routers/settings.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { router, staffProcedure, adminProcedure } from '@/server/trpc/init';
 import type { AppSetting } from '@prisma/client';
 import { deleteFromStorageBestEffort } from '@/lib/storage/blob-storage';
+import { parseLogoValue } from '@/server/helpers/settings';
 
 const settingCategories = z.enum([
   'organization', 'pricing', 'email', 'accounting', 'maintenance', 'documents',
@@ -11,20 +12,6 @@ type SettingCategory = z.infer<typeof settingCategories>;
 
 function mapSetting(s: AppSetting) {
   return { ...s, category: s.category as SettingCategory };
-}
-
-/**
- * Lit la valeur stockée du logo (JSON-stringified, ou en clair pour les lignes
- * legacy) et retourne l'URL, ou `undefined` si la valeur est absente/vide.
- */
-function parseLogoValue(value: unknown): string | undefined {
-  if (typeof value !== 'string' || !value.trim()) return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    return typeof parsed === 'string' && parsed.trim() ? parsed : undefined;
-  } catch {
-    return value;
-  }
 }
 
 const settingSchema = z.object({

--- a/test/unit/upload-routes.spec.ts
+++ b/test/unit/upload-routes.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * Routes de televersement (TD-025).
+ *
+ * Trois appels du navigateur n'avaient aucune route en face : le logo de
+ * l'association et les documents PDF d'un enfant etaient impossibles a
+ * televerser. Ces tests couvrent l'authentification, l'habilitation, la
+ * validation du fichier et les deux garde-fous ajoutes :
+ * - le nom du blob du logo est unique (sinon `settings.setLogoUrl` supprime
+ *   le fichier qui vient d'etre televerse) ;
+ * - un echec d'ecriture en base annule le blob deja televerse.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const authMock = vi.fn();
+const uploadToStorage = vi.fn();
+const deleteFromStorageBestEffort = vi.fn();
+const appSettingFindUnique = vi.fn();
+const childDocumentCreate = vi.fn();
+const childFindFirst = vi.fn();
+const childParentFindFirst = vi.fn();
+
+vi.mock('@/lib/auth', () => ({ auth: () => authMock() }));
+
+vi.mock('@/lib/storage/blob-storage', () => ({
+  uploadToStorage: (...args: unknown[]) => uploadToStorage(...args),
+  deleteFromStorageBestEffort: (...args: unknown[]) =>
+    deleteFromStorageBestEffort(...args),
+}));
+
+vi.mock('@/server/db', () => ({
+  prisma: {
+    appSetting: { findUnique: (...a: unknown[]) => appSettingFindUnique(...a) },
+    childDocument: { create: (...a: unknown[]) => childDocumentCreate(...a) },
+    child: { findFirst: (...a: unknown[]) => childFindFirst(...a) },
+    childParent: { findFirst: (...a: unknown[]) => childParentFindFirst(...a) },
+  },
+}));
+
+import { POST as logoPost, DELETE as logoDelete } from '@/app/api/upload/logo/route';
+import { POST as documentPost } from '@/app/api/upload/child-documents/route';
+
+const ADMIN = { user: { id: 'a0000000-0000-4000-a000-000000000001', role: 'ADMIN' } };
+const PARENT = { user: { id: 'a0000000-0000-4000-a000-000000000003', role: 'PARENT' } };
+const CHILD_ID = 'c0000000-0000-4000-a000-000000000001';
+
+function pngFile(size = 128) {
+  return new File([new Uint8Array(size)], 'logo.png', { type: 'image/png' });
+}
+
+function pdfFile(size = 1024, name = 'certificat.pdf') {
+  return new File([new Uint8Array(size)], name, { type: 'application/pdf' });
+}
+
+function postRequest(formData: FormData) {
+  return new Request('http://localhost/api/upload', {
+    method: 'POST',
+    body: formData,
+  }) as any;
+}
+
+function deleteRequest(body: unknown) {
+  return new Request('http://localhost/api/upload/logo', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  uploadToStorage.mockResolvedValue({
+    pathname: 'organization/logo.png',
+    url: 'https://blob.vercel-storage.com/organization/logo.png',
+  });
+  deleteFromStorageBestEffort.mockResolvedValue(true);
+});
+
+describe('POST /api/upload/logo', () => {
+  it('refuse un visiteur non authentifié', async () => {
+    authMock.mockResolvedValue(null);
+    const form = new FormData();
+    form.append('file', pngFile());
+
+    const res = await logoPost(postRequest(form));
+
+    expect(res.status).toBe(401);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('refuse un PARENT (logo = réglage ADMIN)', async () => {
+    authMock.mockResolvedValue(PARENT);
+    const form = new FormData();
+    form.append('file', pngFile());
+
+    const res = await logoPost(postRequest(form));
+
+    expect(res.status).toBe(403);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('refuse un format non autorisé', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    const form = new FormData();
+    form.append('file', new File(['x'], 'virus.exe', { type: 'application/octet-stream' }));
+
+    const res = await logoPost(postRequest(form));
+
+    expect(res.status).toBe(400);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('refuse un fichier au-delà de 2 Mo', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    const form = new FormData();
+    form.append('file', pngFile(2 * 1024 * 1024 + 1));
+
+    const res = await logoPost(postRequest(form));
+
+    expect(res.status).toBe(400);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('téléverse et retourne l’URL du blob', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    const form = new FormData();
+    form.append('file', pngFile());
+
+    const res = await logoPost(postRequest(form));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      url: 'https://blob.vercel-storage.com/organization/logo.png',
+    });
+    expect(uploadToStorage).toHaveBeenCalledWith(expect.any(Buffer), {
+      pathname: expect.stringMatching(/^organization\/logo-[0-9a-f-]{36}\.png$/),
+      contentType: 'image/png',
+    });
+  });
+
+  it('donne un nom de blob différent à chaque téléversement', async () => {
+    authMock.mockResolvedValue(ADMIN);
+
+    for (let i = 0; i < 2; i++) {
+      const form = new FormData();
+      form.append('file', pngFile());
+      await logoPost(postRequest(form));
+    }
+
+    // Sans cette unicité, `settings.setLogoUrl` supprimerait le blob précédent
+    // — qui serait le nouveau, à URL identique (TD-006).
+    const pathnames = uploadToStorage.mock.calls.map((c: any[]) => c[1].pathname);
+    expect(new Set(pathnames).size).toBe(2);
+  });
+
+  it('répond 500 si le store est injoignable', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    uploadToStorage.mockRejectedValue(new Error('BLOB_READ_WRITE_TOKEN absent'));
+    const form = new FormData();
+    form.append('file', pngFile());
+
+    const res = await logoPost(postRequest(form));
+
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('DELETE /api/upload/logo', () => {
+  it('refuse un PARENT', async () => {
+    authMock.mockResolvedValue(PARENT);
+
+    const res = await logoDelete(deleteRequest({ url: 'https://blob/x.png' }));
+
+    expect(res.status).toBe(403);
+    expect(deleteFromStorageBestEffort).not.toHaveBeenCalled();
+  });
+
+  it('refuse une URL qui n’est pas le logo enregistré', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    appSettingFindUnique.mockResolvedValue({
+      value: JSON.stringify('https://blob/organization/logo-1.png'),
+    });
+
+    const res = await logoDelete(
+      deleteRequest({ url: 'https://blob/invoices/FA-2026-0001.pdf' }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(deleteFromStorageBestEffort).not.toHaveBeenCalled();
+  });
+
+  it('supprime le blob du logo enregistré', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    appSettingFindUnique.mockResolvedValue({
+      value: JSON.stringify('https://blob/organization/logo-1.png'),
+    });
+
+    const res = await logoDelete(
+      deleteRequest({ url: 'https://blob/organization/logo-1.png' }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteFromStorageBestEffort).toHaveBeenCalledWith(
+      'https://blob/organization/logo-1.png',
+      expect.any(String),
+    );
+  });
+});
+
+describe('POST /api/upload/child-documents', () => {
+  function documentForm(overrides: { childId?: string; description?: string } = {}) {
+    const form = new FormData();
+    form.append('file', pdfFile());
+    form.append('childId', overrides.childId ?? CHILD_ID);
+    if (overrides.description) form.append('description', overrides.description);
+    return form;
+  }
+
+  it('refuse un visiteur non authentifié', async () => {
+    authMock.mockResolvedValue(null);
+
+    const res = await documentPost(postRequest(documentForm()));
+
+    expect(res.status).toBe(401);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('refuse un fichier qui n’est pas un PDF', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    const form = new FormData();
+    form.append('file', pngFile());
+    form.append('childId', CHILD_ID);
+
+    const res = await documentPost(postRequest(form));
+
+    expect(res.status).toBe(400);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('refuse un identifiant d’enfant malformé', async () => {
+    authMock.mockResolvedValue(ADMIN);
+
+    const res = await documentPost(postRequest(documentForm({ childId: 'pas-un-uuid' })));
+
+    expect(res.status).toBe(400);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('répond 404 pour un PARENT non rattaché à l’enfant', async () => {
+    authMock.mockResolvedValue(PARENT);
+    childParentFindFirst.mockResolvedValue(null);
+
+    const res = await documentPost(postRequest(documentForm()));
+
+    expect(res.status).toBe(404);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+
+  it('crée le document pour un PARENT rattaché', async () => {
+    authMock.mockResolvedValue(PARENT);
+    childParentFindFirst.mockResolvedValue({ id: 'link-1' });
+    childDocumentCreate.mockImplementation(async ({ data }: any) => ({
+      id: 'd0000000-0000-4000-a000-000000000001',
+      ...data,
+    }));
+
+    const res = await documentPost(
+      postRequest(documentForm({ description: '  Certificat médical  ' })),
+    );
+
+    expect(res.status).toBe(200);
+    expect(childDocumentCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        childId: CHILD_ID,
+        originalFilename: 'certificat.pdf',
+        mimeType: 'application/pdf',
+        fileSize: 1024,
+        description: 'Certificat médical',
+        uploadedBy: PARENT.user.id,
+        fileUrl: 'https://blob.vercel-storage.com/organization/logo.png',
+      }),
+    });
+    expect(uploadToStorage).toHaveBeenCalledWith(expect.any(Buffer), {
+      pathname: expect.stringMatching(
+        new RegExp(`^child-documents/${CHILD_ID}/[0-9a-f-]{36}\\.pdf$`),
+      ),
+      contentType: 'application/pdf',
+    });
+  });
+
+  it('supprime le blob si l’enregistrement en base échoue', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    childFindFirst.mockResolvedValue({ id: CHILD_ID });
+    childDocumentCreate.mockRejectedValue(new Error('deadlock'));
+
+    const res = await documentPost(postRequest(documentForm()));
+
+    expect(res.status).toBe(500);
+    expect(deleteFromStorageBestEffort).toHaveBeenCalledWith(
+      'https://blob.vercel-storage.com/organization/logo.png',
+      expect.any(String),
+    );
+  });
+
+  it('répond 404 pour un ADMIN quand l’enfant n’existe pas', async () => {
+    authMock.mockResolvedValue(ADMIN);
+    childFindFirst.mockResolvedValue(null);
+
+    const res = await documentPost(postRequest(documentForm()));
+
+    expect(res.status).toBe(404);
+    expect(uploadToStorage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## TD-025 — le téléversement, enfin branché (P1)

Trois appels `fetch` du navigateur visaient des routes qui n'existaient **dans aucun commit** : le logo de l'association et les documents PDF d'un enfant étaient impossibles à téléverser depuis la refonte, avec un « Erreur lors de l'upload » pour seule explication.

| Route | Habilitation | Contenu |
|---|---|---|
| `POST /api/upload/logo` | ADMIN | valide MIME (PNG/JPEG/SVG) et taille (2 Mo) **côté serveur**, téléverse, retourne `{ url }` |
| `DELETE /api/upload/logo` | ADMIN | n'efface que le blob dont l'URL **est celle enregistrée** dans `app_settings.organization.logo_url` |
| `POST /api/upload/child-documents` | PARENT (ses enfants) / STAFF / ADMIN | valide PDF + 5 Mo, applique la règle d'accès enfant, téléverse puis crée la ligne `child_documents` |

Un `File` ne traverse pas tRPC/superjson : ce sont des routes HTTP, et c'est la route qui porte la création de la ligne (il n'y a pas de `childDocuments.create`).

### Deux garde-fous, chacun avec son test

- **Nom de blob aléatoire pour le logo** (`organization/logo-<uuid>.<ext>`). À nom fixe, l'URL du nouveau logo serait identique à celle de l'ancien, et la suppression du précédent que fait `settings.setLogoUrl` (TD-006) effacerait le fichier tout juste téléversé.
- **Le blob est annulé si l'écriture en base échoue** — pendant amont de TD-006 : blob d'abord, ligne ensuite, donc c'est l'échec de la ligne qui laisserait un objet public et facturé sans référence.

Le `DELETE` est volontairement restreint : sans comparaison à l'URL enregistrée, la route acceptait d'effacer n'importe quel objet du store (PDF de facture, document d'enfant) sur simple URL.

La règle d'accès à un enfant vit désormais dans `server/helpers/child-access.helper.ts`, partagée entre le routeur et la route — une seule définition, refus 404 indistinct des deux côtés.

### Reste ouvert, dit explicitement

- **Documents du personnel** : toujours pas de dépôt, mais **aucun écran ne le demande** — écrire la route sans l'écran créerait une procédure sans appelant (motif TD-010). Fonctionnalité à spécifier, pas un appel mort à réparer.
- **Couverture de recette** : ni `pnpm smoke` ni `pnpm recette` ne couvrent un téléversement. Les 17 tests ajoutés sont unitaires (store et base mockés) : ils prouvent les habilitations et les garde-fous, pas qu'un blob Vercel est réellement écrit.

## Chaîne de build

- **`packageManager: pnpm@9.15.9`** — trois environnements installaient avec trois pnpm différents : Vercel en 9 (déduit de `lockfileVersion: 9.0`), le CI en 10, les postes de dev en 11. Version choisie = celle que la production utilise déjà, donc rien ne bouge côté prod.
- **`pnpm-workspace.yaml` supprimé** — il avait été commité avec les valeurs **modèles** de `pnpm approve-builds` (« set this to true or false »), illisibles pour pnpm : aucun script d'installation autorisé, donc pas de `prisma generate` au `postinstall`. C'est ce qui faisait échouer `pnpm typecheck` en local. Marche à suivre en cas de passage à pnpm ≥ 10 documentée dans `docs/deploiement.md`.
- **`next build` ajouté au CI** — les tests sont mockés et `tsc` ne voit pas le rendu : rien ne rattrapait une régression de build, d'autant que les previews Vercel échouent toutes.

## Échecs de déploiement Vercel — instruits, pas corrigés à l'aveugle

Les previews échouent **une seconde** après la création du déploiement (statuts GitHub : créé à 00:13:36, `failure` à 00:13:37). Un install + build prend des minutes : c'est un déploiement **refusé avant de démarrer**.

| Piste | Verdict |
|---|---|
| Régression de code | Exclue — `pnpm build` passe en local, et la PR #31 (documentation seule) échoue aussi |
| Variable d'environnement nécessaire au build | Exclue — le build tourne sans aucune variable, toutes les pages du tableau de bord sont dynamiques |
| Étape d'installation pnpm | Improbable — l'échec est immédiat |

Restent trois causes, toutes côté projet Vercel (variable Preview référençant un secret supprimé, quota d'équipe, intégration Neon qui échoue à créer la branche de preview). Elles se départagent avec `npx vercel inspect dpl_… --logs`, qui demande un compte Vercel — le dépôt ne porte aucun jeton. Procédure dans `docs/deploiement.md` § « Échecs de déploiement en preview ».

**Le check Vercel de cette PR échouera donc lui aussi**, comme sur #26 à #31, pour la même raison d'environnement.

## Vérifications

`tsc --noEmit` OK · eslint 0 erreur (35 warnings `any` préexistants) · **995 tests** dont 17 nouveaux · `next build` OK, les deux routes apparaissent en `ƒ`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)