### PR TITLE
docs: troisième renvoi TD cassé par la renumérotation

### DIFF
--- a/components/staff/attendances/attendance-grid.tsx
+++ b/components/staff/attendances/attendance-grid.tsx
@@ -31,7 +31,7 @@ interface AttendanceGridProps {
   attendees: ChildAttendance[];
   // La grille ne pointe qu'un statut : elle n'a ni champ de saisie libre, ni
   // horaire. Le serveur accepte `notes` / `arrivalTime` / `departureTime`,
-  // qu'aucun écran ne remplit (TD-023).
+  // qu'aucun écran ne remplit (TD-027).
   onMarkAttendance: (registrationId: string, status: AttendanceStatus) => void;
   isPending: boolean;
 }


### PR DESCRIPTION
`components/staff/attendances/attendance-grid.tsx:34` renvoyait à **TD-023** pour décrire les trois champs d'entrée du pointage (`notes`, `arrivalTime`, `departureTime`) qu'aucun écran ne remplit.

Depuis la fusion des PR #28, #29 et #30 — qui créaient chacune un `TD-023` différent et ont donc dû être renumérotées — TD-023 désigne les sous-composants shadcn jamais rendus. Le constat du pointage est **TD-027**.

`ef390d7` avait déjà réparé deux renvois de la même origine (`registration-form.tsx` et le tableau de `dette-technique.md`) ; celui-ci avait échappé au balayage.

**Balayage complet effectué** : les six autres renvois à TD-023..027 dans le dépôt (CLAUDE.md, CHANGELOG.md, les routes d'upload, `dette-technique.md`, `registration-form.tsx`) pointent tous sur la bonne entrée. Au passage, TD-025 est bien passé en `DONE (2026-08-19)` avec la livraison des routes de téléversement par la PR #32.

## Vérification

CI GitHub Actions bloqué pour facturation. Vérifié en local sur cette branche :

- `tsc --noEmit` → 0 erreur
- `eslint .` → 0 erreur (35 warnings `any`, pré-existants, tracés en TD-001)
- `vitest run` → **995 tests verts** (31 fichiers)
- `next build` → compile, 61 pages générées

🤖 Generated with [Claude Code](https://claude.com/claude-code)