### PR TITLE
docs: CLAUDE.md renvoyait à un fichier d'extension inexistant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,9 @@ avoir consomme peut etre reimpute par le FIFO et le compte 4191 se retrouve
 debite plus qu'il n'a ete credite.
 
 ### Plus de RLS PostgreSQL
-Le filtrage est applicatif via Prisma extensions. Le `soft-delete.extension.ts`
-filtre automatiquement les enregistrements supprimes. Le filtrage par tenant/parent
+Le filtrage est applicatif via Prisma extensions. `server/extensions/soft-delete.ts`
+filtre automatiquement les enregistrements supprimes (voir `SOFT_DELETE_MODELS` pour
+la liste des modeles concernes). Le filtrage par tenant/parent
 sera gere par les guards tRPC et la logique des routers.
 
 ### tRPC Server Components


### PR DESCRIPTION
`CLAUDE.md` citait `soft-delete.extension.ts` pour expliquer le filtrage des enregistrements supprimés. Ce fichier n'existe nulle part dans le dépôt — l'extension Prisma vit dans **`server/extensions/soft-delete.ts`**.

Le chemin complet est donné, et `SOFT_DELETE_MODELS` est citée au passage : c'est elle qui porte la liste des modèles soumis au filtrage, information qu'on venait justement chercher.

## Balayage complet du fichier

Les **18 autres renvois** de `CLAUDE.md` pointant sur un chemin existent tous (`lib/trpc/server.ts`, `server/services/accounting.service.ts`, `prisma/reset-data.sql`, `test/helpers/test-caller.ts`…). Les deux commandes documentées (`pnpm smoke`, `pnpm recette`) sont bien dans `package.json`.

Le renvoi à `accounting.helper.ts` est **conservé volontairement** : il désigne explicitement l'ancien emplacement de `createPaymentEntries()` / `createRefundEntries()` avant leur migration, pas un fichier courant.

## Vérification

Modification limitée à un fichier de documentation. La vérification complète a été passée sur `master` juste avant, à l'occasion de la PR #33 : `tsc --noEmit` 0 erreur, `eslint .` 0 erreur, **995 tests verts**, `next build` 61 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)